### PR TITLE
Fix format for py26

### DIFF
--- a/sample/dla/02_spinchain/exec.py
+++ b/sample/dla/02_spinchain/exec.py
@@ -16,34 +16,33 @@ Ms = [1,2]
 Ts = [0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.25, 1.5, 1.75, 2.0]
 
 for M in Ms:
-    output = open('{}_{}.dat'.format(name,M), 'w')
+    output = open('{0}_{1}.dat'.format(name,M), 'w')
     for i,T in enumerate(Ts):
-        with open('std_{}_{}.in'.format(M,i), 'w') as f:
+        with open('std_{0}_{1}.in'.format(M,i), 'w') as f:
             f.write('''
-    solver = DLA
-    model_type = spin
-    J = -1
-    F = 0.0
-    lattice_type = square
-    D = 1
-    L = 30
-    nset = 5
-    ntherm = 1000
-    ndecor = 1000
-    nmcs = 1000
-           ''')
-            f.write('M = {}\n'.format(M))
-            f.write('beta = {}\n'.format(1.0/T))
-            f.write('outfile = res_{}_{}.dat\n'.format(M,i))
-        cmd = [os.path.join(bindir, 'dsqss_pre.py'), '-p', 'param_{}_{}.in'.format(M,i), '-i', 'std_{}_{}.in'.format(M,i)]
+solver = DLA
+model_type = spin
+J = -1
+F = 0.0
+lattice_type = square
+D = 1
+L = 30
+nset = 5
+ntherm = 1000
+ndecor = 1000
+nmcs = 1000''')
+            f.write('M = {0}\n'.format(M))
+            f.write('beta = {0}\n'.format(1.0/T))
+            f.write('outfile = res_{0}_{1}.dat\n'.format(M,i))
+        cmd = [os.path.join(bindir, 'dsqss_pre.py'), '-p', 'param_{0}_{1}.in'.format(M,i), '-i', 'std_{0}_{1}.in'.format(M,i)]
         subprocess.call(cmd)
-        cmd = [os.path.join(bindir, 'dla_H'), 'param_{}_{}.in'.format(M,i)]
+        cmd = [os.path.join(bindir, 'dla_H'), 'param_{0}_{1}.in'.format(M,i)]
         subprocess.call(cmd)
-        with open('res_{}_{}.dat'.format(M,i)) as f:
+        with open('res_{0}_{1}.dat'.format(M,i)) as f:
             for line in f:
                 if not line.startswith('R'):
                     continue
                 words = line.split()
                 if words[1] == name:
-                    output.write('{} {} {}\n'.format(T, words[3], words[4]))
+                    output.write('{0} {1} {2}\n'.format(T, words[3], words[4]))
 

--- a/sample/dla/03_bosesquare/exec.py
+++ b/sample/dla/03_bosesquare/exec.py
@@ -14,10 +14,10 @@ else:
 name = 'amzu'
 mus = [-4.0, -2.0, 0.0, 2.0, 2.5, 3.0, 6.0, 9.0, 9.5, 10.0, 12.0, 14.0]
 
-output = open('{}.dat'.format(name), 'w')
+output = open('{0}.dat'.format(name), 'w')
 
 for i,mu in enumerate(mus):
-    with open('std_{}.in'.format(i), 'w') as f:
+    with open('std_{0}.in'.format(i), 'w') as f:
         f.write('''
 solver = DLA
 model_type = boson
@@ -32,20 +32,19 @@ L = 8,8
 nset = 4
 ntherm = 100
 ndecor = 100
-nmcs = 100
-       ''')
-        f.write('F = {}\n'.format(mu/4))
-        f.write('algfile = algorithm_{}.xml\n'.format(i))
-        f.write('outfile = res_{}.dat\n'.format(i))
-    cmd = [os.path.join(bindir, 'dsqss_pre.py'), '-p', 'param_{}.in'.format(i), '-i', 'std_{}.in'.format(i)]
+nmcs = 100''')
+        f.write('F = {0}\n'.format(mu/4))
+        f.write('algfile = algorithm_{0}.xml\n'.format(i))
+        f.write('outfile = res_{0}.dat\n'.format(i))
+    cmd = [os.path.join(bindir, 'dsqss_pre.py'), '-p', 'param_{0}.in'.format(i), '-i', 'std_{0}.in'.format(i)]
     subprocess.call(cmd)
-    cmd = [os.path.join(bindir, 'dla_B'), 'param_{}.in'.format(i)]
+    cmd = [os.path.join(bindir, 'dla_B'), 'param_{0}.in'.format(i)]
     subprocess.call(cmd)
-    with open('res_{}.dat'.format(i)) as f:
+    with open('res_{0}.dat'.format(i)) as f:
         for line in f:
             if not line.startswith('R'):
                 continue
             words = line.split()
             if words[1] == name:
-                output.write('{} {} {}\n'.format(mu, words[3], words[4]))
+                output.write('{0} {1} {2}\n'.format(mu, words[3], words[4]))
 

--- a/test/dla/checkpoint.py
+++ b/test/dla/checkpoint.py
@@ -17,21 +17,21 @@ simtime = 1.0
 
 def evaluate(name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
 
-    res1 = read_result('res{}.dat'.format(name))
-    SF1 = read_result('sf{}.dat'.format(name))
-    CF1 = read_result('cf{}.dat'.format(name))
-    CK1 = read_result('ck{}.dat'.format(name))
+    res1 = read_result('res{0}.dat'.format(name))
+    SF1 = read_result('sf{0}.dat'.format(name))
+    CF1 = read_result('cf{0}.dat'.format(name))
+    CK1 = read_result('ck{0}.dat'.format(name))
     res1['SF'] = SF1
     res1['CF'] = CF1
     res1['CK'] = CK1
     res1.pop('time')
 
-    res2 = read_result('res{}_restarted.dat'.format(name))
-    SF2 = read_result('sf{}_restarted.dat'.format(name))
-    CF2 = read_result('cf{}_restarted.dat'.format(name))
-    CK2 = read_result('ck{}_restarted.dat'.format(name))
+    res2 = read_result('res{0}_restarted.dat'.format(name))
+    SF2 = read_result('sf{0}_restarted.dat'.format(name))
+    CF2 = read_result('cf{0}_restarted.dat'.format(name))
+    CK2 = read_result('ck{0}_restarted.dat'.format(name))
     res2['SF'] = SF2
     res2['CF'] = CF2
     res2['CK'] = CK2
@@ -63,15 +63,15 @@ else:
     exename = 'dla_H'
 
 cleanup(ID)
-cleanup('{}_restarted'.format(ID))
+cleanup('{0}_restarted'.format(ID))
 genXML(param, BINDIR=BINDIR, name=ID)
 geninp(beta, SEED, nset=nset, simtime=simtime, name=ID)
 run(exename, BINDIR=BINDIR, name=ID)
 geninp(beta, 2*SEED, nset=nset, simtime='INF', name=ID)
 run(exename, BINDIR=BINDIR, name=ID)
 for nm in ['res','sf','cf','ck']:
-    shutil.move('{}_{}.dat'.format(nm,ID), '{}_{}_restarted.dat'.format(nm,ID))
-os.remove('res_{}.dat.0.cjob'.format(ID))
+    shutil.move('{0}_{1}.dat'.format(nm,ID), '{0}_{1}_restarted.dat'.format(nm,ID))
+os.remove('res_{0}.dat.0.cjob'.format(ID))
 
 geninp(beta, SEED, nset=nset, simtime=0.0, name=ID)
 run(exename, BINDIR=BINDIR, name=ID)

--- a/test/dla/common.py
+++ b/test/dla/common.py
@@ -12,7 +12,7 @@ def p_value(X, E, N, Y):
 
 def cleanup(name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
     for prefix, suffix in [('hamiltonian', '.xml'),
                            ('algorithm', '.xml'),
                            ('lattice', '.xml'),
@@ -24,14 +24,14 @@ def cleanup(name=''):
                            ('ck', '.dat'),
                            ('cjob.res', '.dat'),
                            ]:
-        fname = '{}{}{}'.format(prefix, name, suffix)
+        fname = '{0}{1}{2}'.format(prefix, name, suffix)
         if os.path.exists(fname):
             os.remove(fname)
 
 
 def genXML(param, BINDIR='.', name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
 
     D = param['D']
     z = 2*D
@@ -41,7 +41,7 @@ def genXML(param, BINDIR='.', name=''):
         V = param['V']
         U = param['U']/z
         mu = param['mu']/z
-        retval = sub.call(['{}/generators/hamgen_B'.format(BINDIR), str(M), str(t), str(V), str(U), str(mu)])
+        retval = sub.call(['{0}/generators/hamgen_B'.format(BINDIR), str(M), str(t), str(V), str(U), str(mu)])
         if retval != 0:
             sys.exit(retval)
     elif param['Model'] == 'spin':
@@ -56,76 +56,76 @@ def genXML(param, BINDIR='.', name=''):
             print('ERROR: Jz != Jxy')
             sys.exit(1)
         h = param['h']/z
-        retval = sub.call(['{}/generators/hamgen_H'.format(BINDIR), str(M), str(Jz), str(h)])
+        retval = sub.call(['{0}/generators/hamgen_H'.format(BINDIR), str(M), str(Jz), str(h)])
         if retval != 0:
             sys.exit(retval)
     else:
         print('ERROR: unknown model')
         sys.exit(1)
 
-    retval = sub.call(['{}/generators/dla_alg'.format(BINDIR)])
+    retval = sub.call(['{0}/generators/dla_alg'.format(BINDIR)])
     if retval != 0:
         sys.exit(retval)
-    shutil.move('hamiltonian.xml', 'hamiltonian{}.xml'.format(name))
-    shutil.move('algorithm.xml', 'algorithm{}.xml'.format(name))
+    shutil.move('hamiltonian.xml', 'hamiltonian{0}.xml'.format(name))
+    shutil.move('algorithm.xml', 'algorithm{0}.xml'.format(name))
 
     L = param['L']
     # beta = param['beta']
     beta = 1.0
-    cmds = ['{}/generators/lattgene_C'.format(BINDIR), str(D)]
+    cmds = ['{0}/generators/lattgene_C'.format(BINDIR), str(D)]
     cmds.extend(map(str,L))
     cmds.append(str(beta))
     retval = sub.call(cmds)
     if retval != 0:
         sys.exit(retval)
-    shutil.move('lattice.xml', 'lattice{}.xml'.format(name))
+    shutil.move('lattice.xml', 'lattice{0}.xml'.format(name))
 
     ntau = param['ntau']
 
-    cmds = ['{}/generators/sfgene'.format(BINDIR), str(D)]
+    cmds = ['{0}/generators/sfgene'.format(BINDIR), str(D)]
     cmds.extend(map(str,L))
     cmds.extend([str(ntau), str(ntau), '0'])
     retval = sub.call(cmds)
     if retval != 0:
         sys.exit(retval)
-    shutil.move('sf.xml', 'sf{}.xml'.format(name))
+    shutil.move('sf.xml', 'sf{0}.xml'.format(name))
 
-    cmds = ['{}/generators/cfgene'.format(BINDIR), str(D)]
+    cmds = ['{0}/generators/cfgene'.format(BINDIR), str(D)]
     cmds.extend(map(str,L))
     cmds.append(str(ntau))
     retval = sub.call(cmds)
     if retval != 0:
         sys.exit(retval)
-    shutil.move('cf.xml', 'cf{}.xml'.format(name))
+    shutil.move('cf.xml', 'cf{0}.xml'.format(name))
 
 def geninp(beta, seed, nset=10, nmcs=1000, ntherm=1000, npre=1000, simtime=0.0, name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
 
-    with open('qmc{}.inp'.format(name), 'w') as f:
+    with open('qmc{0}.inp'.format(name), 'w') as f:
         f.write('runtype = 0\n')
-        f.write('beta = {}\n'.format(beta))
-        f.write('seed = {}\n'.format(seed))
-        f.write('nset = {}\n'.format(nset))
-        f.write('nmcs = {}\n'.format(nmcs))
-        f.write('ntherm = {}\n'.format(ntherm))
-        f.write('npre = {}\n'.format(npre))
-        f.write('simulationtime = {}\n'.format(simtime))
-        f.write('latfile = lattice{}.xml\n'.format(name))
-        f.write('algfile = algorithm{}.xml\n'.format(name))
-        f.write('outfile = res{}.dat\n'.format(name))
-        f.write('sfinpfile = sf{}.xml\n'.format(name))
-        f.write('cfinpfile = cf{}.xml\n'.format(name))
-        f.write('ckinpfile = sf{}.xml\n'.format(name))
-        f.write('sfoutfile = sf{}.dat\n'.format(name))
-        f.write('cfoutfile = cf{}.dat\n'.format(name))
-        f.write('ckoutfile = ck{}.dat\n'.format(name))
+        f.write('beta = {0}\n'.format(beta))
+        f.write('seed = {0}\n'.format(seed))
+        f.write('nset = {0}\n'.format(nset))
+        f.write('nmcs = {0}\n'.format(nmcs))
+        f.write('ntherm = {0}\n'.format(ntherm))
+        f.write('npre = {0}\n'.format(npre))
+        f.write('simulationtime = {0}\n'.format(simtime))
+        f.write('latfile = lattice{0}.xml\n'.format(name))
+        f.write('algfile = algorithm{0}.xml\n'.format(name))
+        f.write('outfile = res{0}.dat\n'.format(name))
+        f.write('sfinpfile = sf{0}.xml\n'.format(name))
+        f.write('cfinpfile = cf{0}.xml\n'.format(name))
+        f.write('ckinpfile = sf{0}.xml\n'.format(name))
+        f.write('sfoutfile = sf{0}.dat\n'.format(name))
+        f.write('cfoutfile = cf{0}.dat\n'.format(name))
+        f.write('ckoutfile = ck{0}.dat\n'.format(name))
 
 def run(exename, BINDIR='.', name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
 
-    retval = sub.call(['{}/{}'.format(BINDIR,exename), 'qmc{}.inp'.format(name)])
+    retval = sub.call(['{0}/{1}'.format(BINDIR,exename), 'qmc{0}.inp'.format(name)])
     if retval != 0:
         sys.exit(retval)
 

--- a/test/dla/test.py
+++ b/test/dla/test.py
@@ -26,16 +26,16 @@ NPRE = 1000
 
 def evaluate(ref, nset, alpha, name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
 
-    res = read_result('res{}.dat'.format(name))
-    SF = read_result('sf{}.dat'.format(name))
+    res = read_result('res{0}.dat'.format(name))
+    SF = read_result('sf{0}.dat'.format(name))
     res['SF'] = SF
 
     if test_Green:
-        CF = read_result('cf{}.dat'.format(name))
+        CF = read_result('cf{0}.dat'.format(name))
         res['CF'] = CF
-        CK = read_result('ck{}.dat'.format(name))
+        CK = read_result('ck{0}.dat'.format(name))
         res['CK'] = CK
 
     failed = 0
@@ -47,23 +47,23 @@ def evaluate(ref, nset, alpha, name=''):
             Y = ref[name]
             p = p_value(X, E, nset, Y)
             if p < alpha:
-                print('NG: {}: X={}, E={}, Y={}, t={}, p={}'.format(name, X, E, Y, (X-Y)/E, p))
+                print('NG: {0}: X={1}, E={2}, Y={3}, t={4}, p={5}'.format(name, X, E, Y, (X-Y)/E, p))
                 failed += 1
             else:
-                print('OK: {}: X={}, E={}, Y={}, t={}, p={}'.format(name, X, E, Y, (X-Y)/E, p))
+                print('OK: {0}: X={1}, E={2}, Y={3}, t={4}, p={5}'.format(name, X, E, Y, (X-Y)/E, p))
         else:
             y = np.array(ref[name])
             nk, ntau = y.shape
             for ik in range(nk):
                 for it in range(ntau):
-                    X,E = res[name]['C{}t{}'.format(ik,it)]
+                    X,E = res[name]['C{0}t{1}'.format(ik,it)]
                     Y = y[ik,it]
                     p = p_value(X, E, nset, Y)
                     if p < alpha:
-                        print('NG: {}[C{}t{}]: X={}, E={}, Y={}, t={}, p={}'.format(name, ik, it, X, E, Y, (X-Y)/E, p))
+                        print('NG: {0}[C{1}t{2}]: X={3}, E={4}, Y={5}, t={6}, p={7}'.format(name, ik, it, X, E, Y, (X-Y)/E, p))
                         failed += 1
                     else:
-                        print('OK: {}[C{}t{}]: X={}, E={}, Y={}, t={}, p={}'.format(name, ik, it, X, E, Y, (X-Y)/E, p))
+                        print('OK: {0}[C{1}t{2}]: X={3}, E={4}, Y={5}, t={6}, p={7}'.format(name, ik, it, X, E, Y, (X-Y)/E, p))
     if failed > 0:
         sys.exit(1)
 

--- a/test/pmwa/test.py
+++ b/test/pmwa/test.py
@@ -23,39 +23,39 @@ def p_value(X, E, N, Y):
 
 def cleanup(name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
     for prefix, suffix in [('lattice', '.xml'),
                            ('res', '.dat.0'),
                            ('evout_res', '.dat.0_rank0.dat'),
                            ('RNDevout_res', '.dat.0_rank0.dat'),
                            ('qmc_', '.inp'),
                            ]:
-        fname = '{}{}{}'.format(prefix, name, suffix)
+        fname = '{0}{1}{2}'.format(prefix, name, suffix)
         if os.path.exists(fname):
             os.remove(fname)
 
 def genXML(param, name=''):
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
     L = param['L']
     D = param['D']
     # beta = param['beta']
     beta = 1.0
 
-    cmd = ['{}/lattgene_P'.format(BINDIR), str(D)]
+    cmd = ['{0}/lattgene_P'.format(BINDIR), str(D)]
     cmd.extend(map(str,L))
     cmd.extend([str(beta), '1', '1', '0'])
 
     retval = sub.call(cmd)
     if retval != 0:
         sys.exit(retval)
-    shutil.move('lattice.xml', 'lattice{}.xml'.format(name))
+    shutil.move('lattice.xml', 'lattice{0}.xml'.format(name))
 
 
 def geninp(param, seed, nset=10, name=''):
     beta = param['beta']
     if name != '':
-        name = '_{}'.format(name)
+        name = '_{0}'.format(name)
     if param['Model'] == 'boson':
         D = param['D']
         t = param['t']
@@ -72,34 +72,34 @@ def geninp(param, seed, nset=10, name=''):
         mu = param['h']
         G = param['G']
         M = int(2*param['S'])
-    with open('qmc{}.inp'.format(name), 'w') as f:
+    with open('qmc{0}.inp'.format(name), 'w') as f:
         f.write('runtype = 0\n')
-        f.write('nset = {}\n'.format(nset))
+        f.write('nset = {0}\n'.format(nset))
         f.write('ntherm = 1000\n')
         f.write('ndecor = 1000\n')
         f.write('nmcs  = 1000\n')
         f.write('npre = 1000\n')
         f.write('nvermax = 10000000\n')
         f.write('nwormax = 1000\n')
-        f.write('seed = {}\n'.format(seed))
-        f.write('latfile = lattice{}.xml\n'.format(name))
-        f.write('outfile = res{}.dat\n'.format(name))
-        f.write('beta = {}\n'.format(beta))
-        f.write('oldbeta = {}\n'.format(beta))
+        f.write('seed = {0}\n'.format(seed))
+        f.write('latfile = lattice{0}.xml\n'.format(name))
+        f.write('outfile = res{0}.dat\n'.format(name))
+        f.write('beta = {0}\n'.format(beta))
+        f.write('oldbeta = {0}\n'.format(beta))
         f.write('CB = 0\n')
-        f.write('G = {}\n'.format(G))
-        f.write('t = {}\n'.format(t))
-        f.write('V = {}\n'.format(V))
-        f.write('u = {}\n'.format(U))
-        f.write('mu = {}\n'.format(mu))
+        f.write('G = {0}\n'.format(G))
+        f.write('t = {0}\n'.format(t))
+        f.write('V = {0}\n'.format(V))
+        f.write('u = {0}\n'.format(U))
+        f.write('mu = {0}\n'.format(mu))
         f.write('Wc = 0\n')
         f.write('PS = 1\n')
-        f.write('NMAX = {}\n'.format(M))
+        f.write('NMAX = {0}\n'.format(M))
 
 def run(exename, name=''):
     if name != '':
-        name = '_{}'.format(name)
-    retval = sub.call(['{}/{}'.format(BINDIR,exename), 'qmc{}.inp'.format(name)])
+        name = '_{0}'.format(name)
+    retval = sub.call(['{0}/{1}'.format(BINDIR,exename), 'qmc{0}.inp'.format(name)])
     if retval != 0:
         sys.exit(retval)
 
@@ -116,8 +116,8 @@ def read_result(filename):
 
 def evaluate(ref, nset, alpha, name=''):
     if name != '':
-        name = '_{}'.format(name)
-    res = read_result('res{}.dat.0'.format(name))
+        name = '_{0}'.format(name)
+    res = read_result('res{0}.dat.0'.format(name))
     failed = 0
     for name in ref:
         X,E = res[name]
@@ -126,10 +126,10 @@ def evaluate(ref, nset, alpha, name=''):
         Y = ref[name]
         p = p_value(X, E, nset, Y)
         if p < alpha:
-            print('NG: {}: X={}, E={}, Y={}, t={}, p={}'.format(name, X, E, Y, (X-Y)/E, p))
+            print('NG: {0}: X={1}, E={2}, Y={3}, t={4}, p={5}'.format(name, X, E, Y, (X-Y)/E, p))
             failed += 1
         else:
-            print('OK: {}: X={}, E={}, Y={}, t={}, p={}'.format(name, X, E, Y, (X-Y)/E, p))
+            print('OK: {0}: X={1}, E={2}, Y={3}, t={4}, p={5}'.format(name, X, E, Y, (X-Y)/E, p))
     if failed > 0:
         sys.exit(1)
 

--- a/tool/dsqss_pre.py
+++ b/tool/dsqss_pre.py
@@ -91,7 +91,7 @@ class info:
         self.gendir = args.gendir
         if self.gendir is None:
             self.gendir = os.path.abspath(os.path.dirname(__file__))
-            print('use file generators in {}'.format(self.gendir))
+            print('use file generators in {0}'.format(self.gendir))
         self._get_info(args.input)
         self._check_condition()
         
@@ -191,7 +191,7 @@ class info:
         LatticeInfo=self._get_latticeinfo()
         genpath = self._get_lattgene()
         if not os.path.exists(genpath):
-            raise RuntimeError('{} is not found: use correct --generator_dir.'.format(genpath))
+            raise RuntimeError('{0} is not found: use correct --generator_dir.'.format(genpath))
         cmd = [genpath, '-o', self.prm.param_dict["latfile"]]
         for l in LatticeInfo:
             cmd.append(str(l))
@@ -210,7 +210,7 @@ class info:
             model_type = self.prm.info_dict["model_type"]
             genpath = os.path.join(self.gendir, self.dict_hamgen[model_type])
             if not os.path.exists(genpath):
-                raise RuntimeError('{} is not found: use correct --generator_dir.'.format(genpath))
+                raise RuntimeError('{0} is not found: use correct --generator_dir.'.format(genpath))
             if model_type == "spin":
                 cmd = [genpath,
                        '-o', hfile,
@@ -229,7 +229,7 @@ class info:
             subprocess.call(cmd)
             genpath = os.path.join(self.gendir, 'dla_alg')
             if not os.path.exists(genpath):
-                raise RuntimeError('{} is not found: use correct --generator_dir.'.format(genpath))
+                raise RuntimeError('{0} is not found: use correct --generator_dir.'.format(genpath))
             cmd = [genpath, hfile, self.prm.param_dict["algfile"]]
             print("\n" + ' '.join(cmd))
             subprocess.call(cmd)
@@ -237,7 +237,7 @@ class info:
             if len(self.prm.param_dict["sfinpfile"]) > 0:
                 genpath = os.path.join(self.gendir, 'sfgene')
                 if not os.path.exists(genpath):
-                    raise RuntimeError('{} is not found: use correct --generator_dir.'.format(genpath))
+                    raise RuntimeError('{0} is not found: use correct --generator_dir.'.format(genpath))
                 cmd = [genpath,
                         '-o', self.prm.param_dict["sfinpfile"],
                         ]
@@ -251,7 +251,7 @@ class info:
             if len(self.prm.param_dict["cfinpfile"]) > 0:
                 genpath = os.path.join(self.gendir, 'cfgene')
                 if not os.path.exists(genpath):
-                    raise RuntimeError('{} is not found: use correct --generator_dir.'.format(genpath))
+                    raise RuntimeError('{0} is not found: use correct --generator_dir.'.format(genpath))
                 cmd = [genpath,
                         '-o', self.prm.param_dict["cfinpfile"],
                         ]
@@ -263,7 +263,7 @@ class info:
             if len(self.prm.param_dict["ckinpfile"]) > 0:
                 genpath = os.path.join(self.gendir, 'sfgene')
                 if not os.path.exists(genpath):
-                    raise RuntimeError('{} is not found: use correct --generator_dir.'.format(genpath))
+                    raise RuntimeError('{0} is not found: use correct --generator_dir.'.format(genpath))
                 cmd = [genpath,
                         '-o', self.prm.param_dict["ckinpfile"],
                         ]


### PR DESCRIPTION
`str.format` in python2.6 requires placeholders with position number (without number is valid after py2.7)