### PR TITLE
Fix pip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,9 @@ if(BUILD_NEW_GENERATORS OR Testing OR Document)
       execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U pip)
     endif(NOT PIP_FOUND)
     foreach(module_name ${missing_modules})
-      message(STATUS "${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}")
+      message(STATUS "PIP_USER=0 ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}")
       execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}
+        COMMAND PIP_USER=0 ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}
         )
     endforeach(module_name ${missing_modules})
   endif(num_missing_modules)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,9 @@ if(BUILD_NEW_GENERATORS OR Testing OR Document)
       execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip install -U pip)
     endif(NOT PIP_FOUND)
     foreach(module_name ${missing_modules})
-      message(STATUS "PIP_USER=0 ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}")
+      message(STATUS "env PIP_USER=0 PYTHONPATH=${pythonpath_build}:\$PYTHONPATH ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}")
       execute_process(
-        COMMAND PIP_USER=0 ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}
+        COMMAND env PIP_USER=0 PYTHONPATH=${pythonpath_build}:\$PYTHONPATH ${PYTHON_EXECUTABLE} -m pip install --prefix=${pythonpath_prefix} ${module_name}
         )
     endforeach(module_name ${missing_modules})
   endif(num_missing_modules)

--- a/tool/cmake/install.sh.in
+++ b/tool/cmake/install.sh.in
@@ -5,18 +5,18 @@ cd @CMAKE_CURRENT_BINARY_DIR@
 if ! @PYTHON_EXECUTABLE@ -m pip --version >/dev/null 2>/dev/null ;then
   set -e
   wget https://bootstrap.pypa.io/get-pip.py -O get-pip.py
-  @PYTHON_EXECUTABLE@ get-pip.py --prefix=@CMAKE_INSTALL_PREFIX@
+  PIP_USER=0 @PYTHON_EXECUTABLE@ get-pip.py --prefix=@CMAKE_INSTALL_PREFIX@
 fi
 
 set -e
-@PYTHON_EXECUTABLE@ -m pip install wheel --prefix=@CMAKE_INSTALL_PREFIX@ --no-warn-script-location
+PIP_USER=0 @PYTHON_EXECUTABLE@ -m pip install wheel --prefix=@CMAKE_INSTALL_PREFIX@ --no-warn-script-location
 DSQSS_VERSION=$(@PYTHON_EXECUTABLE@ setup.py --version)
 @PYTHON_EXECUTABLE@ setup.py bdist_wheel --universal
 mkdir -p temp
 cd temp
 
 # install dependencies if not installed
-@PYTHON_EXECUTABLE@ -m pip install ../dist/dsqss-${DSQSS_VERSION}-py2.py3-none-any.whl --prefix=@CMAKE_INSTALL_PREFIX@ --no-warn-script-location
+PIP_USER=0 @PYTHON_EXECUTABLE@ -m pip install ../dist/dsqss-${DSQSS_VERSION}-py2.py3-none-any.whl --prefix=@CMAKE_INSTALL_PREFIX@ --no-warn-script-location
 
 # forcely install dsqss
-@PYTHON_EXECUTABLE@ -m pip install --no-deps --force-reinstall ../dist/dsqss-${DSQSS_VERSION}-py2.py3-none-any.whl --prefix=@CMAKE_INSTALL_PREFIX@ --no-warn-script-location
+PIP_USER=0 @PYTHON_EXECUTABLE@ -m pip install --no-deps --force-reinstall ../dist/dsqss-${DSQSS_VERSION}-py2.py3-none-any.whl --prefix=@CMAKE_INSTALL_PREFIX@ --no-warn-script-location


### PR DESCRIPTION
Some environments (including MALIVE! 2.3) added `--user` option to `pip install` automatically, in result, installation of python module fails because of confliction of `--prefix` and `--user`. To avoid it, set `PIP_USER=0`.