### PR TITLE
Drop Python 3.6, 3.7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ DSQSS implements the path-integral Monte Carlo method with the directed loop alg
 
 - C++ Compiler
 - CMake >=2.8.12
-- Python >=3.6
+- Python >=3.8
   - numpy
   - scipy
   - toml
-  - typing_extensions
 
 ### Simple build
 

--- a/doc/en/dsqss/install.rst
+++ b/doc/en/dsqss/install.rst
@@ -8,12 +8,11 @@ Requirements
 ********************
 
 - (Optional) MPI (essential for PMWA)
-- python 3.6+
+- python 3.8+
 
    - numpy
    - scipy
    - toml
-   - typing_extensions
    - pip (essential for ``make install``)
 
 Download

--- a/doc/jp/dsqss/install.rst
+++ b/doc/jp/dsqss/install.rst
@@ -9,12 +9,11 @@
 DSQSSの使用には以下のプログラム・ライブラリが必要です. 
 
 - (Optional) MPI (PMWAを使用する場合には必須)
-- python 3.6+
+- python 3.8+
 
    - numpy
    - scipy
    - toml
-   - typing_extensions
    
 
 ダウンロード

--- a/tool/dsqss/prob_kernel.py
+++ b/tool/dsqss/prob_kernel.py
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Sequence
-from typing_extensions import Protocol
+from typing import Sequence, Protocol
 
 import numpy as np
 

--- a/tool/pyproject.toml
+++ b/tool/pyproject.toml
@@ -12,12 +12,11 @@ packages = [
   ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.8"
 # Users should install dependencies by themselves
 # numpy = "^1.17"
 # toml = ">= 0.10.0"
 # scipy = "^1"
-# typing-extensions = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Official support of Python3.7 has ended.
`typing_extensions` is no longer required.