### PR TITLE
Add unit tests for tool/dsqss and fix bugs they uncovered

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
           python -m pip install -U pip
           python -m pip install numpy scipy toml
           python -m pip install typing_extensions
+          python -m pip install pytest
 
       - name: make workspace
         run: cmake -E make_directory ${{runner.workspace}}/build

--- a/test/tool/CMakeLists.txt
+++ b/test/tool/CMakeLists.txt
@@ -2,7 +2,7 @@ file(COPY ${CMAKE_BINARY_DIR}/tool/pmwa_pre DESTINATION ${CMAKE_CURRENT_BINARY_D
 # configure_file(${CMAKE_SOURCE_DIR}/tool/cmake/pmwa_pre.in ${CMAKE_CURRENT_BINARY_DIR}/pmwa_pre @ONLY)
 set(BUILD_TOOL_DIR ${CMAKE_BINARY_DIR}/tool)
 function(add_python_test test)
-    add_test(NAME python_${test} COMMAND ${PYTHON_EXECUTABLE} ${test}.py)
+    add_test(NAME python_${test} COMMAND ${PYTHON_EXECUTABLE} -m pytest ${test}.py -v --tb=short)
     set_tests_properties(python_${test} PROPERTIES ENVIRONMENT "PYTHONPATH=${BUILD_TOOL_DIR}")
 endfunction(add_python_test)
 
@@ -10,6 +10,20 @@ file(GLOB_RECURSE TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 foreach(testfile ${TEST_FILES})
     configure_file(${testfile} ${CMAKE_BINARY_DIR}/test/tool COPYONLY)
 endforeach()
+
+set(python_unit_test_src
+  test_util
+  test_read_keyvalues
+  test_prob_kernel
+  test_parameter
+  test_result
+  test_lattice_factory
+  test_lattice
+  test_hamiltonian
+  test_displacement
+  test_wavevector
+  test_algorithm
+)
 
 if(MPI_FOUND)
 set(python_test_src
@@ -21,6 +35,8 @@ set(python_test_src
   #   test_dsqss_pre_dla
 )
 endif(MPI_FOUND)
+
+list(APPEND python_test_src ${python_unit_test_src})
 foreach(test ${python_test_src})
     add_python_test(${test})
 endforeach(test)

--- a/test/tool/CMakeLists.txt
+++ b/test/tool/CMakeLists.txt
@@ -23,6 +23,7 @@ set(python_unit_test_src
   test_displacement
   test_wavevector
   test_algorithm
+  test_pmwa_pre_unit
 )
 
 if(MPI_FOUND)

--- a/test/tool/conftest.py
+++ b/test/tool/conftest.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+
+from dsqss.lattice_factory.hypercubic import generate as hypercubic_generate
+from dsqss.lattice import Lattice
+
+
+@pytest.fixture
+def chain_lattice_dict():
+    return hypercubic_generate({"dim": 1, "L": 4})
+
+
+@pytest.fixture
+def chain_lattice(chain_lattice_dict):
+    lat = Lattice()
+    lat.load_dict(chain_lattice_dict)
+    return lat
+
+
+@pytest.fixture
+def square_lattice_dict():
+    return hypercubic_generate({"dim": 2, "L": [4, 4]})
+
+
+@pytest.fixture
+def square_lattice(square_lattice_dict):
+    lat = Lattice()
+    lat.load_dict(square_lattice_dict)
+    return lat
+
+
+@pytest.fixture
+def spin_half_ham():
+    from dsqss.xxz import XXZ_hamiltonian
+    return XXZ_hamiltonian({"M": 1, "Jz": 1.0, "Jxy": 1.0})
+
+
+@pytest.fixture
+def graphed_ham(spin_half_ham, chain_lattice):
+    from dsqss.hamiltonian import GraphedHamiltonian
+    return GraphedHamiltonian(spin_half_ham, chain_lattice)

--- a/test/tool/test_algorithm.py
+++ b/test/tool/test_algorithm.py
@@ -1,0 +1,53 @@
+import types
+import pytest
+
+from dsqss.algorithm import AlgSite, AlgInteraction, Algorithm
+
+
+# ---- AlgSite / AlgInteraction / Algorithm built from the S=1/2 XXZ chain ----
+
+def test_algsite_created_for_each_site(graphed_ham):
+    alg = Algorithm(graphed_ham)
+    assert len(alg.sites) == graphed_ham.nstypes
+
+
+def test_alginteraction_created_for_each_indeed_interaction(graphed_ham):
+    alg = Algorithm(graphed_ham)
+    assert len(alg.interactions) == len(graphed_ham.indeed_interactions)
+
+
+def test_algsite_channels_nonempty(graphed_ham):
+    alg = Algorithm(graphed_ham)
+    site = alg.sites[0]
+    assert len(site.initialconfigurations) > 0
+
+
+def test_alginteraction_vertex_created(graphed_ham):
+    alg = Algorithm(graphed_ham)
+    for interaction in alg.interactions:
+        assert interaction.vertex is not None
+
+
+def test_algorithm_write_xml(graphed_ham, tmp_path):
+    alg = Algorithm(graphed_ham)
+    path = str(tmp_path / "algorithm.xml")
+    alg.write_xml(path)
+    with open(path) as f:
+        content = f.read()
+    assert "<Algorithm>" in content
+
+
+# ---- known bug: ZeroDivisionError when a site has zero states ----
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Bug: algorithm.py:274 — 'ndiag' is the product of each site's N "
+           "(number of states); if any site has N=0, ndiag stays 0 and "
+           "(2*maxo - sumw) / ndiag raises ZeroDivisionError instead of a "
+           "clear validation error.",
+)
+def test_alginteraction_zero_states_site_raises_informative_error():
+    fake_site = types.SimpleNamespace(N=0, sources={})
+    hamint = types.SimpleNamespace(itype=0, stypes=[0], nbody=1, elements={})
+    with pytest.raises(ValueError):
+        AlgInteraction(hamint, [fake_site])

--- a/test/tool/test_algorithm.py
+++ b/test/tool/test_algorithm.py
@@ -39,13 +39,6 @@ def test_algorithm_write_xml(graphed_ham, tmp_path):
 
 # ---- known bug: ZeroDivisionError when a site has zero states ----
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Bug: algorithm.py:274 — 'ndiag' is the product of each site's N "
-           "(number of states); if any site has N=0, ndiag stays 0 and "
-           "(2*maxo - sumw) / ndiag raises ZeroDivisionError instead of a "
-           "clear validation error.",
-)
 def test_alginteraction_zero_states_site_raises_informative_error():
     fake_site = types.SimpleNamespace(N=0, sources={})
     hamint = types.SimpleNamespace(itype=0, stypes=[0], nbody=1, elements={})

--- a/test/tool/test_displacement.py
+++ b/test/tool/test_displacement.py
@@ -1,0 +1,94 @@
+import pytest
+import numpy as np
+
+from dsqss.displacement import Displacement
+from dsqss.lattice import Lattice
+from dsqss.lattice_factory.hypercubic import generate as hypercubic_generate
+
+
+def _open_chain(L=4):
+    lat = Lattice()
+    lat.load_dict(hypercubic_generate({"dim": 1, "L": L, "bc": False}))
+    return lat
+
+
+# ---- basic attributes ----
+
+def test_displacement_nsites(chain_lattice):
+    d = Displacement(chain_lattice)
+    assert d.nsites == 4
+
+
+def test_displacement_matrix_shape(chain_lattice):
+    d = Displacement(chain_lattice)
+    assert d.displacements.shape == (4, 4)
+
+
+# ---- self-displacement consistency ----
+
+def test_displacement_self_is_same_kind(chain_lattice):
+    d = Displacement(chain_lattice)
+    kinds = {d.displacements[i, i] for i in range(d.nsites)}
+    assert len(kinds) == 1, "all self-displacements must map to the same kind"
+
+
+def test_displacement_self_is_kind_zero(chain_lattice):
+    d = Displacement(chain_lattice)
+    for i in range(d.nsites):
+        assert d.displacements[i, i] == 0
+
+
+# ---- translation symmetry ----
+
+def test_displacement_translation_symmetry(chain_lattice):
+    d = Displacement(chain_lattice)
+    # sites 0→1 and 1→2 have the same displacement vector (+1)
+    assert d.displacements[0, 1] == d.displacements[1, 2]
+    assert d.displacements[1, 2] == d.displacements[2, 3]
+
+
+# ---- periodic boundary ----
+
+def test_displacement_nkinds_periodic_chain(chain_lattice):
+    d = Displacement(chain_lattice)
+    # L=4 periodic: unique displacements are 0, +1, +2, -1 → 4 kinds
+    assert d.nkinds == 4
+
+
+def test_displacement_periodic_wrapping(chain_lattice):
+    d = Displacement(chain_lattice)
+    # In a periodic L=4 chain: 0→3 wraps to displacement -1, same as 1→0
+    assert d.displacements[0, 3] == d.displacements[1, 0]
+
+
+# ---- open boundary ----
+
+def test_displacement_open_boundary_nkinds():
+    lat = _open_chain(4)
+    d = Displacement(lat)
+    # No wrapping: displacements are 0, ±1, ±2, ±3 → 7 kinds
+    assert d.nkinds == 7
+
+
+def test_displacement_open_no_wrap():
+    lat = _open_chain(4)
+    d = Displacement(lat)
+    # 0→3 and 0→1 should be different kinds (dr=3 vs dr=1, no wrapping)
+    assert d.displacements[0, 3] != d.displacements[0, 1]
+
+
+# ---- distance_only mode ----
+
+def test_displacement_distance_only_reduces_nkinds(chain_lattice):
+    d_full = Displacement(chain_lattice, distance_only=False)
+    d_dist = Displacement(chain_lattice, distance_only=True)
+    # distance_only merges ±dr into same kind → fewer or equal kinds
+    assert d_dist.nkinds <= d_full.nkinds
+
+
+def test_displacement_distance_only_symmetric(chain_lattice):
+    d = Displacement(chain_lattice, distance_only=True)
+    # distance is symmetric: d(i,j) kind == d(j,i) kind
+    for i in range(d.nsites):
+        for j in range(d.nsites):
+            assert d.displacements[i, j] == d.displacements[j, i]

--- a/test/tool/test_hamiltonian.py
+++ b/test/tool/test_hamiltonian.py
@@ -1,0 +1,138 @@
+import pytest
+
+from dsqss.hamiltonian import (
+    keystate,
+    States,
+    append_matelem,
+    Site,
+    Interaction,
+    Hamiltonian,
+    GraphedHamiltonian,
+)
+from dsqss.xxz import XXZ_hamiltonian
+
+
+# ---- keystate ----
+
+def test_keystate_int_input():
+    s = keystate(0, 1)
+    assert s == States(initial=(0,), final=(1,))
+
+
+def test_keystate_list_input():
+    s = keystate([0, 1], [1, 0])
+    assert s == States(initial=(0, 1), final=(1, 0))
+
+
+def test_keystate_diagonal():
+    s = keystate(2, 2)
+    assert s.initial == s.final
+
+
+# ---- append_matelem ----
+
+def test_append_matelem_state_form():
+    m = {}
+    append_matelem(m, state=0, value=1.5)
+    assert m[keystate(0, 0)] == 1.5
+
+
+def test_append_matelem_istate_fstate_form():
+    m = {}
+    append_matelem(m, istate=0, fstate=1, value=-0.5)
+    assert m[keystate(0, 1)] == -0.5
+
+
+def test_append_matelem_missing_value_raises():
+    with pytest.raises(RuntimeError, match="value"):
+        append_matelem({}, state=0)
+
+
+def test_append_matelem_missing_state_raises():
+    with pytest.raises(RuntimeError):
+        append_matelem({}, value=1.0)
+
+
+def test_append_matelem_returns_matelems():
+    m = {}
+    result = append_matelem(m, state=0, value=1.0)
+    assert result is m
+
+
+# ---- Hamiltonian (via dict) ----
+
+def test_hamiltonian_from_dict():
+    d = {
+        "name": "test",
+        "sites": [{"type": 0, "N": 2, "values": [0.0, 1.0], "elements": [], "sources": []}],
+        "interactions": [{"type": 0, "nbody": 1, "N": [2], "elements": []}],
+    }
+    h = Hamiltonian(d)
+    assert h.nstypes == 1
+    assert h.nitypes == 1
+    assert h.nxmax == 2
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Bug: hamiltonian.py:229,240 — RuntimeError raised with empty message. "
+           "Should include context about which site/interaction slot is None.",
+)
+def test_hamiltonian_missing_site_gives_informative_error():
+    # Two sites in list, both with type=0 — leaves type=1 slot as None
+    bad = {
+        "name": "bad",
+        "sites": [
+            {"type": 0, "N": 2, "values": [0.0, 1.0], "elements": [], "sources": []},
+            {"type": 0, "N": 2, "values": [0.0, 1.0], "elements": [], "sources": []},
+        ],
+        "interactions": [],
+    }
+    with pytest.raises(RuntimeError, match=r".+"):  # fails because message is ""
+        Hamiltonian(bad)
+
+
+# ---- XXZ_hamiltonian ----
+
+def test_xxz_spin_half_nstypes():
+    h = XXZ_hamiltonian({"M": 1, "Jz": 1.0, "Jxy": 1.0})
+    assert h.nstypes == 1
+
+
+def test_xxz_spin_half_site_n():
+    h = XXZ_hamiltonian({"M": 1, "Jz": 1.0, "Jxy": 1.0})
+    assert h.sites[0].N == 2
+
+
+def test_xxz_spin_half_diagonal_elements():
+    h = XXZ_hamiltonian({"M": 1, "Jz": 1.0, "Jxy": 0.0})
+    bond = h.interactions[0]
+    # [↓↓]: -Jz * (-0.5)*(-0.5) = -0.25
+    assert abs(bond.elements[keystate([0, 0], [0, 0])] - (-0.25)) < 1e-10
+    # [↑↑]: -Jz * (0.5)*(0.5) = -0.25
+    assert abs(bond.elements[keystate([1, 1], [1, 1])] - (-0.25)) < 1e-10
+    # [↓↑]: -Jz * (-0.5)*(0.5) = +0.25
+    assert abs(bond.elements[keystate([0, 1], [0, 1])] - 0.25) < 1e-10
+
+
+def test_xxz_spin_half_offdiagonal_elements():
+    h = XXZ_hamiltonian({"M": 1, "Jz": 0.0, "Jxy": 1.0})
+    bond = h.interactions[0]
+    # spin-flip: [↓↑] → [↑↓] and [↑↓] → [↓↑]
+    assert keystate([0, 1], [1, 0]) in bond.elements
+    assert keystate([1, 0], [0, 1]) in bond.elements
+
+
+# ---- GraphedHamiltonian ----
+
+def test_graphed_ham_indeed_interactions_nonempty(graphed_ham):
+    assert len(graphed_ham.indeed_interactions) > 0
+
+
+def test_graphed_ham_nitypes_equals_vertex_count(graphed_ham, chain_lattice):
+    assert graphed_ham.nitypes == len(chain_lattice.vertices)
+
+
+def test_graphed_ham_nxmax(graphed_ham):
+    # S=1/2 has 2 states → nxmax = 2
+    assert graphed_ham.nxmax == 2

--- a/test/tool/test_hamiltonian.py
+++ b/test/tool/test_hamiltonian.py
@@ -73,22 +73,41 @@ def test_hamiltonian_from_dict():
     assert h.nxmax == 2
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Bug: hamiltonian.py:229,240 — RuntimeError raised with empty message. "
-           "Should include context about which site/interaction slot is None.",
-)
+def _site_dict(stype):
+    return {"type": stype, "N": 2, "values": [0.0, 1.0], "elements": [], "sources": []}
+
+
 def test_hamiltonian_missing_site_gives_informative_error():
     # Two sites in list, both with type=0 — leaves type=1 slot as None
     bad = {
         "name": "bad",
-        "sites": [
-            {"type": 0, "N": 2, "values": [0.0, 1.0], "elements": [], "sources": []},
-            {"type": 0, "N": 2, "values": [0.0, 1.0], "elements": [], "sources": []},
-        ],
+        "sites": [_site_dict(0), _site_dict(0)],
         "interactions": [],
     }
-    with pytest.raises(RuntimeError, match=r".+"):  # fails because message is ""
+    with pytest.raises(RuntimeError, match=r"site type 1 is not defined"):
+        Hamiltonian(bad)
+
+
+def test_hamiltonian_out_of_range_site_type():
+    bad = {
+        "name": "bad",
+        "sites": [_site_dict(0), _site_dict(2)],  # 2 sites but type 2
+        "interactions": [],
+    }
+    with pytest.raises(RuntimeError, match=r"site type 2 is out of range"):
+        Hamiltonian(bad)
+
+
+def test_hamiltonian_missing_interaction_gives_informative_error():
+    bad = {
+        "name": "bad",
+        "sites": [_site_dict(0)],
+        "interactions": [
+            {"type": 0, "nbody": 2, "N": [2, 2], "elements": []},
+            {"type": 0, "nbody": 2, "N": [2, 2], "elements": []},
+        ],
+    }
+    with pytest.raises(RuntimeError, match=r"interaction type 1 is not defined"):
         Hamiltonian(bad)
 
 

--- a/test/tool/test_lattice.py
+++ b/test/tool/test_lattice.py
@@ -82,3 +82,16 @@ def test_lattice_dat_roundtrip(chain_lattice, tmp_path):
     assert lat2.nints == chain_lattice.nints
     assert lat2.dim == chain_lattice.dim
     assert lat2.name == chain_lattice.name
+    assert lat2.bc == chain_lattice.bc
+
+
+def test_lattice_dat_roundtrip_open_bc(tmp_path):
+    # save_dat writes bc as "0"/"1"; load_dat must not turn "0" into True
+    # (bool("0") is True for any non-empty string)
+    lat = _open_chain(4)
+    assert lat.bc == [False]
+    path = str(tmp_path / "open_chain.dat")
+    lat.save_dat(path)
+    lat2 = Lattice()
+    lat2.load_dat(path)
+    assert lat2.bc == [False]

--- a/test/tool/test_lattice.py
+++ b/test/tool/test_lattice.py
@@ -1,0 +1,84 @@
+import pytest
+import numpy as np
+
+from dsqss.lattice import Lattice
+from dsqss.lattice_factory.hypercubic import generate as hypercubic_generate
+
+
+def _open_chain(L=4):
+    lat = Lattice()
+    lat.load_dict(hypercubic_generate({"dim": 1, "L": L, "bc": False}))
+    return lat
+
+
+# ---- site counts ----
+
+def test_chain_nsites(chain_lattice):
+    assert chain_lattice.nsites == 4
+
+
+def test_chain_site_types_are_zero(chain_lattice):
+    for site in chain_lattice.sites:
+        assert site.stype == 0
+
+
+def test_square_nsites(square_lattice):
+    assert square_lattice.nsites == 16
+
+
+# ---- interaction counts ----
+
+def test_chain_nints_periodic(chain_lattice):
+    assert chain_lattice.nints == 4
+
+
+def test_chain_nints_open():
+    lat = _open_chain(4)
+    assert lat.nints == 3
+
+
+def test_square_nints_periodic(square_lattice):
+    # 2 bonds per cell × 16 cells = 32
+    assert square_lattice.nints == 32
+
+
+# ---- coordination numbers ----
+
+def test_chain_coordination_number(chain_lattice):
+    for site in chain_lattice.sites:
+        assert site.z == 2
+
+
+def test_chain_open_boundary_endpoint_coordination():
+    lat = _open_chain(4)
+    # endpoints (sites 0 and 3) are in only 1 bond; interior sites are in 2
+    zs = [site.z for site in lat.sites]
+    assert zs[0] == 1
+    assert zs[-1] == 1
+    assert all(z == 2 for z in zs[1:-1])
+
+
+# ---- vertices ----
+
+def test_chain_has_one_vertex_type(chain_lattice):
+    assert len(chain_lattice.vertices) == 1
+
+
+# ---- site coordinates ----
+
+def test_chain_site_coords(chain_lattice):
+    coords = [site.coord[0] for site in chain_lattice.sites]
+    assert coords == [0.0, 1.0, 2.0, 3.0]
+
+
+# ---- dat file roundtrip ----
+
+def test_lattice_dat_roundtrip(chain_lattice, tmp_path):
+    path = str(tmp_path / "chain.dat")
+    chain_lattice.save_dat(path)
+    lat2 = Lattice()
+    lat2.load_dat(path)
+    assert lat2.nsites == chain_lattice.nsites
+    assert lat2.nints == chain_lattice.nints
+    assert lat2.dim == chain_lattice.dim
+    assert lat2.name == chain_lattice.name

--- a/test/tool/test_lattice_factory.py
+++ b/test/tool/test_lattice_factory.py
@@ -1,0 +1,105 @@
+import pytest
+
+from dsqss.lattice import Lattice
+from dsqss.lattice_factory.hypercubic import generate as hypercubic_generate
+from dsqss.lattice_factory.triangular import generate as triangular_generate
+from dsqss.lattice_factory.honeycomb import generate as honeycomb_generate
+from dsqss.lattice_factory.kagome import generate as kagome_generate
+
+
+# ---- helpers ----
+
+def _sites(d):
+    return d["unitcell"]["sites"]
+
+
+def _bonds(d):
+    return d["unitcell"]["bonds"]
+
+
+def _make_lattice(d):
+    lat = Lattice()
+    lat.load_dict(d)
+    return lat
+
+
+# ---- hypercubic ----
+
+def test_hypercubic_1d_one_site_one_bond():
+    d = hypercubic_generate({"dim": 1, "L": 4})
+    assert len(_sites(d)) == 1
+    assert len(_bonds(d)) == 1
+
+
+def test_hypercubic_2d_one_site_two_bonds():
+    d = hypercubic_generate({"dim": 2, "L": [4, 4]})
+    assert len(_sites(d)) == 1
+    assert len(_bonds(d)) == 2
+
+
+def test_hypercubic_3d_one_site_three_bonds():
+    d = hypercubic_generate({"dim": 3, "L": [2, 2, 2]})
+    assert len(_sites(d)) == 1
+    assert len(_bonds(d)) == 3
+
+
+def test_hypercubic_scalar_l_broadcast():
+    d = hypercubic_generate({"dim": 2, "L": 4})
+    assert d["parameter"]["L"] == [4, 4]
+
+
+def test_hypercubic_open_boundary():
+    d = hypercubic_generate({"dim": 1, "L": 4, "bc": False})
+    assert d["parameter"]["bc"] == [False]
+
+
+def test_hypercubic_creates_valid_lattice():
+    d = hypercubic_generate({"dim": 1, "L": 4})
+    _make_lattice(d)  # must not raise
+
+
+# ---- triangular ----
+
+def test_triangular_one_site_three_bonds():
+    d = triangular_generate({"L": [4, 4]})
+    assert len(_sites(d)) == 1
+    assert len(_bonds(d)) == 3
+
+
+def test_triangular_creates_valid_lattice():
+    d = triangular_generate({"L": [4, 4]})
+    _make_lattice(d)
+
+
+# ---- honeycomb ----
+
+def test_honeycomb_two_sites_per_cell():
+    d = honeycomb_generate({"L": [4, 4]})
+    assert len(_sites(d)) == 2
+
+
+def test_honeycomb_three_bonds_per_cell():
+    d = honeycomb_generate({"L": [4, 4]})
+    assert len(_bonds(d)) == 3
+
+
+def test_honeycomb_creates_valid_lattice():
+    d = honeycomb_generate({"L": [4, 4]})
+    _make_lattice(d)
+
+
+# ---- kagome ----
+
+def test_kagome_three_sites_per_cell():
+    d = kagome_generate({"L": [4, 4]})
+    assert len(_sites(d)) == 3
+
+
+def test_kagome_six_bonds_per_cell():
+    d = kagome_generate({"L": [4, 4]})
+    assert len(_bonds(d)) == 6
+
+
+def test_kagome_creates_valid_lattice():
+    d = kagome_generate({"L": [4, 4]})
+    _make_lattice(d)

--- a/test/tool/test_parameter.py
+++ b/test/tool/test_parameter.py
@@ -1,0 +1,65 @@
+import pytest
+
+from dsqss.parameter import set_default_values, check_mandatories, Parameter
+
+
+# ---- set_default_values ----
+
+def test_set_default_values_fills_missing():
+    param = {"beta": 1.0}
+    set_default_values(param)
+    assert param["npre"] == 1000
+    assert param["ntherm"] == 1000
+    assert param["nmcs"] == 1000
+    assert param["algfile"] == "algorithm.xml"
+    assert param["latfile"] == "lattice.xml"
+    assert param["outfile"] == "sample.log"
+
+
+def test_set_default_values_does_not_overwrite():
+    param = {"beta": 1.0, "npre": 500, "nmcs": 200}
+    set_default_values(param)
+    assert param["npre"] == 500
+    assert param["nmcs"] == 200
+
+
+def test_set_default_values_fills_all_defaults():
+    param = {"beta": 1.0}
+    set_default_values(param)
+    expected_keys = [
+        "npre", "ntherm", "ndecor", "nmcs", "nset", "simulationtime",
+        "ntau", "seed", "nvermax", "nsegmax",
+        "algfile", "latfile", "wvfile", "dispfile",
+        "outfile", "sfoutfile", "cfoutfile", "ckoutfile",
+    ]
+    for k in expected_keys:
+        assert k in param, f"missing default key: {k}"
+
+
+# ---- check_mandatories ----
+
+def test_check_mandatories_missing_beta_exits():
+    with pytest.raises(SystemExit):
+        check_mandatories({})
+
+
+def test_check_mandatories_with_beta_passes():
+    check_mandatories({"beta": 1.0})  # must not raise
+
+
+# ---- Parameter class ----
+
+def test_parameter_flat_dict():
+    p = Parameter({"beta": 1.0})
+    assert p["beta"] == 1.0
+    assert "npre" in p  # defaults filled in
+
+
+def test_parameter_nested_dict():
+    p = Parameter({"parameter": {"beta": 2.0}})
+    assert p["beta"] == 2.0
+
+
+def test_parameter_is_dict_subclass():
+    p = Parameter({"beta": 1.0})
+    assert isinstance(p, dict)

--- a/test/tool/test_pmwa_pre_unit.py
+++ b/test/tool/test_pmwa_pre_unit.py
@@ -1,0 +1,63 @@
+import types
+from io import StringIO
+
+import pytest
+
+from dsqss.pmwa_pre import info
+
+
+def _make_info(text):
+    args = types.SimpleNamespace(gendir="/nonexistent", input=StringIO(text))
+    return info(args)
+
+
+PMWA_SPIN_INPUT = """\
+solver = PMWA
+model_type = spin
+Jxy = -1.0
+Jz = -1
+h = 0.25
+gamma = 0.2
+lattice_type = square
+D = 1
+L = 8
+Beta = 10
+"""
+
+
+def test_valid_pmwa_input_parses():
+    inf = _make_info(PMWA_SPIN_INPUT)
+    assert inf.prm.info_dict["solver"] == "PMWA"
+
+
+def test_spin_keyword_mapping():
+    inf = _make_info(PMWA_SPIN_INPUT)
+    # jxy -> t (absolute value: bipartite unitary transform)
+    assert float(inf.prm.param_dict["t"]) == 1.0
+    # jz -> v, h -> mu, gamma -> g (halved for spin)
+    assert float(inf.prm.param_dict["v"]) == -1.0
+    assert float(inf.prm.param_dict["mu"]) == 0.25
+    assert float(inf.prm.param_dict["g"]) == 0.1
+
+
+def test_missing_solver_exits_with_message(capfd):
+    with pytest.raises(SystemExit):
+        _make_info("model_type = spin\nL = 8\n")
+    assert "solver is not specified" in capfd.readouterr().err
+
+
+def test_dla_solver_redirects_to_dla_pre(capfd):
+    with pytest.raises(SystemExit):
+        _make_info("solver = DLA\nL = 8\n")
+    assert "dla_pre" in capfd.readouterr().err
+
+
+def test_unknown_solver_rejected(capfd):
+    with pytest.raises(SystemExit):
+        _make_info("solver = PMWAA\nL = 8\n")
+    assert "unknown solver" in capfd.readouterr().err
+
+
+def test_get_solver_name():
+    inf = _make_info(PMWA_SPIN_INPUT)
+    assert inf.get_solver() == "pmwa_H"

--- a/test/tool/test_prob_kernel.py
+++ b/test/tool/test_prob_kernel.py
@@ -1,0 +1,120 @@
+import sys
+import pytest
+import numpy as np
+
+from dsqss.prob_kernel import heat_bath, metropolis, suwa_todo, reversible_suwa_todo
+
+ALL_KERNELS = [heat_bath, metropolis, suwa_todo, reversible_suwa_todo]
+NONZERO_WEIGHT_CASES = [[1.0, 1.0], [2.0, 1.0], [3.0, 1.0, 0.5]]
+
+
+# ---- shared properties: shape, nonnegativity, row sums ----
+
+@pytest.mark.parametrize("kernel", ALL_KERNELS)
+@pytest.mark.parametrize("weights", NONZERO_WEIGHT_CASES)
+def test_output_shape(kernel, weights):
+    N = len(weights)
+    W = kernel(weights)
+    assert W.shape == (N, N)
+
+
+@pytest.mark.parametrize("kernel", ALL_KERNELS)
+@pytest.mark.parametrize("weights", NONZERO_WEIGHT_CASES)
+def test_nonnegative(kernel, weights):
+    W = kernel(weights)
+    assert np.all(W >= 0.0)
+
+
+@pytest.mark.parametrize("kernel", ALL_KERNELS)
+@pytest.mark.parametrize("weights", NONZERO_WEIGHT_CASES)
+def test_rows_sum_to_one(kernel, weights):
+    W = kernel(weights)
+    np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-10)
+
+
+# ---- heat_bath ----
+
+def test_heat_bath_all_rows_equal():
+    W = heat_bath([1.0, 2.0, 3.0])
+    for i in range(len(W)):
+        np.testing.assert_array_equal(W[i], W[0])
+
+
+def test_heat_bath_uniform_weights():
+    W = heat_bath([1.0, 1.0, 1.0, 1.0])
+    np.testing.assert_allclose(W, 0.25, atol=1e-12)
+
+
+def test_heat_bath_zero_weight_column_is_zero():
+    W = heat_bath([1.0, 0.0, 1.0])
+    np.testing.assert_array_equal(W[:, 1], 0.0)
+
+
+# ---- metropolis ----
+
+def test_metropolis_zero_weight_row_is_zero():
+    W = metropolis([1.0, 0.0, 1.0])
+    np.testing.assert_array_equal(W[1, :], 0.0)
+
+
+def test_metropolis_detailed_balance():
+    weights = [1.0, 2.0, 3.0]
+    W = metropolis(weights)
+    for i in range(len(weights)):
+        for j in range(len(weights)):
+            assert abs(weights[i] * W[i, j] - weights[j] * W[j, i]) < 1e-10
+
+
+def test_metropolis_nonzero_rows_sum_to_one():
+    weights = [1.0, 0.0, 1.0]
+    W = metropolis(weights)
+    assert abs(W[0].sum() - 1.0) < 1e-10
+    assert abs(W[2].sum() - 1.0) < 1e-10
+
+
+# ---- suwa_todo ----
+
+def test_suwa_todo_two_states():
+    W = suwa_todo([1.0, 2.0])
+    assert W.shape == (2, 2)
+    np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-10)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Bug: prob_kernel.py:88 — infinite loop when all remaining targets are 0.0. "
+           "weights=[1.0,0.0,0.0] causes while-loop to spin forever after all targets zeroed.",
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="SIGALRM not available on Windows")
+def test_suwa_todo_single_nonzero_weight_does_not_hang():
+    import signal
+
+    def _timeout(signum, frame):
+        raise TimeoutError("suwa_todo hung — infinite loop confirmed")
+
+    signal.signal(signal.SIGALRM, _timeout)
+    signal.alarm(2)
+    try:
+        suwa_todo([1.0, 0.0, 0.0])
+    finally:
+        signal.alarm(0)
+
+
+# ---- reversible_suwa_todo ----
+
+def test_reversible_suwa_todo_detailed_balance():
+    weights = [1.0, 2.0, 3.0]
+    W = reversible_suwa_todo(weights)
+    for i in range(len(weights)):
+        for j in range(len(weights)):
+            assert abs(weights[i] * W[i, j] - weights[j] * W[j, i]) < 1e-10
+
+
+@pytest.mark.parametrize("kernel", ALL_KERNELS)
+@pytest.mark.parametrize("weights", NONZERO_WEIGHT_CASES)
+def test_kernel_preserves_stationary_distribution(kernel, weights):
+    # p is the equilibrium distribution; a valid transition kernel must
+    # leave it invariant: p @ W == p
+    W = kernel(weights)
+    p = np.array(weights) / sum(weights)
+    np.testing.assert_allclose(p @ W, p, atol=1e-10)

--- a/test/tool/test_prob_kernel.py
+++ b/test/tool/test_prob_kernel.py
@@ -80,24 +80,38 @@ def test_suwa_todo_two_states():
     np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-10)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Bug: prob_kernel.py:88 — infinite loop when all remaining targets are 0.0. "
-           "weights=[1.0,0.0,0.0] causes while-loop to spin forever after all targets zeroed.",
-)
 @pytest.mark.skipif(sys.platform == "win32", reason="SIGALRM not available on Windows")
 def test_suwa_todo_single_nonzero_weight_does_not_hang():
     import signal
 
     def _timeout(signum, frame):
-        raise TimeoutError("suwa_todo hung — infinite loop confirmed")
+        raise TimeoutError("suwa_todo hung — infinite loop")
 
     signal.signal(signal.SIGALRM, _timeout)
     signal.alarm(2)
     try:
-        suwa_todo([1.0, 0.0, 0.0])
+        W = suwa_todo([1.0, 0.0, 0.0])
     finally:
         signal.alarm(0)
+    # the only occupied state can only stay put
+    assert W[0, 0] == 1.0
+    # zero-weight states are never occupied: their rows stay zero
+    np.testing.assert_array_equal(W[1, :], 0.0)
+    np.testing.assert_array_equal(W[2, :], 0.0)
+
+
+@pytest.mark.parametrize("kernel", [suwa_todo, reversible_suwa_todo])
+def test_single_element_weights(kernel):
+    W = kernel([2.0])
+    np.testing.assert_array_equal(W, [[1.0]])
+
+
+def test_suwa_todo_no_nan_with_zero_weights():
+    W = suwa_todo([1.0, 0.0, 2.0])
+    assert not np.any(np.isnan(W))
+    # occupied-state rows are normalized
+    assert abs(W[0, :].sum() - 1.0) < 1e-10
+    assert abs(W[2, :].sum() - 1.0) < 1e-10
 
 
 # ---- reversible_suwa_todo ----

--- a/test/tool/test_read_keyvalues.py
+++ b/test/tool/test_read_keyvalues.py
@@ -1,0 +1,74 @@
+import pytest
+from io import StringIO
+
+from dsqss.read_keyvalues import read_keyvalues, parse_list
+
+
+# ---- read_keyvalues ----
+
+def test_simple_keyvalue():
+    result = read_keyvalues(StringIO("beta = 1.0\n"))
+    assert result == {"beta": "1.0"}
+
+
+def test_comment_stripped():
+    result = read_keyvalues(StringIO("beta = 1.0 # a comment\n"))
+    assert result == {"beta": "1.0"}
+
+
+def test_key_is_lowercased():
+    result = read_keyvalues(StringIO("Beta = 1.0\n"))
+    assert "beta" in result
+    assert "Beta" not in result
+
+
+def test_comma_separated_becomes_list():
+    result = read_keyvalues(StringIO("L = 4,4\n"))
+    assert result["l"] == ["4", "4"]
+
+
+def test_blank_line_ignored():
+    result = read_keyvalues(StringIO("\nbeta = 1.0\n"))
+    assert result == {"beta": "1.0"}
+
+
+def test_comment_only_line_ignored():
+    result = read_keyvalues(StringIO("# full comment line\nbeta = 1.0\n"))
+    assert result == {"beta": "1.0"}
+
+
+def test_multiple_keys():
+    src = "beta = 2.0\nnmcs = 1000\n"
+    result = read_keyvalues(StringIO(src))
+    assert result["beta"] == "2.0"
+    assert result["nmcs"] == "1000"
+
+
+def test_leading_space_in_key_is_handled():
+    # data.strip() on line 34 is not assigned back, but keys are still stripped
+    # individually via d_re.group(1).strip(), so behavior is correct.
+    result = read_keyvalues(StringIO("  beta = 1.0\n"))
+    assert "beta" in result
+    assert "  beta" not in result
+
+
+# ---- parse_list ----
+
+def test_parse_list_scalar_string():
+    assert parse_list("3", 3, int) == [3, 3, 3]
+
+
+def test_parse_list_extends_list():
+    assert parse_list(["1", "2"], 4, int) == [1, 2, 2, 2]
+
+
+def test_parse_list_no_type_conversion():
+    assert parse_list("abc", 2) == ["abc", "abc"]
+
+
+def test_parse_list_exact_length():
+    assert parse_list([1, 2, 3], 3) == [1, 2, 3]
+
+
+def test_parse_list_single_element_repeated():
+    assert parse_list([7], 4) == [7, 7, 7, 7]

--- a/test/tool/test_result.py
+++ b/test/tool/test_result.py
@@ -1,0 +1,70 @@
+import pytest
+
+from dsqss.result import Result, Results
+
+
+# ---- Result ----
+
+def test_result_to_str_default_delim():
+    assert Result(0.5, 0.01).to_str() == "0.5+/-0.01"
+
+
+def test_result_to_str_custom_delim():
+    assert Result(0.5, 0.01).to_str(delim=" +- ") == "0.5 +- 0.01"
+
+
+def test_result_stores_mean_and_err():
+    r = Result(1.234, 0.005)
+    assert r.mean == 1.234
+    assert r.err == 0.005
+
+
+# ---- Results ----
+
+def _write_result_file(path, lines):
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_results_parses_r_lines(tmp_path):
+    f = tmp_path / "result.dat"
+    _write_result_file(f, [
+        "R Energy 0 1.234 0.005 tag",
+        "R Magnetization 0 0.0 0.001 tag",
+    ])
+    r = Results(f)
+    assert abs(r.result["Energy"].mean - 1.234) < 1e-9
+    assert abs(r.result["Energy"].err - 0.005) < 1e-9
+    assert abs(r.result["Magnetization"].mean - 0.0) < 1e-9
+
+
+def test_results_ignores_non_r_lines(tmp_path):
+    f = tmp_path / "result.dat"
+    _write_result_file(f, [
+        "# comment",
+        "  some other line",
+        "R Energy 0 2.0 0.1 tag",
+    ])
+    r = Results(f)
+    assert "Energy" in r.result
+    assert len(r.result) == 1
+
+
+def test_results_to_str_single(tmp_path):
+    f = tmp_path / "result.dat"
+    _write_result_file(f, ["R Energy 0 1.5 0.02 tag"])
+    r = Results(f)
+    # Results.to_str defaults delim=" " (unlike Result.to_str's "+/-" default)
+    assert r.to_str("Energy") == "1.5 0.02"
+    assert r.to_str("Energy", delim="+/-") == "1.5+/-0.02"
+
+
+def test_results_to_str_multiple(tmp_path):
+    f = tmp_path / "result.dat"
+    _write_result_file(f, [
+        "R Energy 0 1.5 0.02 tag",
+        "R Mag 0 0.3 0.01 tag",
+    ])
+    r = Results(f)
+    s = r.to_str(["Energy", "Mag"], delim="+/-")
+    assert "1.5+/-0.02" in s
+    assert "0.3+/-0.01" in s

--- a/test/tool/test_util.py
+++ b/test/tool/test_util.py
@@ -1,0 +1,117 @@
+import pytest
+import math
+
+from dsqss.util import index2coord, coord2index, tagged, extend_list, get_as_list
+
+
+# ---- index2coord ----
+
+def test_index2coord_zero():
+    assert index2coord(0, [4, 4]) == [0, 0]
+
+
+def test_index2coord_linear():
+    # 5 = 1*4 + 1  →  [1, 1]
+    assert index2coord(5, [4, 4]) == [1, 1]
+
+
+def test_index2coord_1d():
+    assert index2coord(3, [6]) == [3]
+
+
+def test_index2coord_3d():
+    # 13 = 1 + 2*4 + 1*16  → [1, 2, 1] in [4,4,4]
+    idx = 1 + 2 * 4 + 1 * 16
+    assert index2coord(idx, [4, 4, 4]) == [1, 2, 1]
+
+
+# ---- coord2index ----
+
+def test_coord2index_zero():
+    assert coord2index([0, 0], [4, 4]) == 0
+
+
+def test_coord2index_known():
+    # r=[1,2], size=[4,4]  →  1 + 2*4 = 9
+    assert coord2index([1, 2], [4, 4]) == 9
+
+
+# ---- roundtrip ----
+
+@pytest.mark.parametrize("size", [[4], [4, 4], [3, 2, 5]])
+def test_index2coord_coord2index_roundtrip(size):
+    total = 1
+    for s in size:
+        total *= s
+    for i in range(total):
+        assert coord2index(index2coord(i, size), size) == i
+
+
+# ---- tagged ----
+
+def test_tagged_scalar_int():
+    assert tagged("Foo", 3) == "<Foo> 3 </Foo>\n"
+
+
+def test_tagged_list_ints():
+    assert tagged("X", [1, 2]) == "<X> 1 2 </X>\n"
+
+
+def test_tagged_string_not_iterated():
+    # strings must not be iterated char-by-char
+    assert tagged("N", "hello") == "<N> hello </N>\n"
+
+
+def test_tagged_float_width_18():
+    result = tagged("X", [1.5])
+    # extract the value between "<X> " and " </X>"
+    inner = result[len("<X> "):result.index(" </X>")]
+    assert len(inner) == 18
+
+
+def test_tagged_float_contains_value():
+    result = tagged("X", [1.5])
+    assert "1.5" in result
+
+
+# ---- extend_list ----
+
+def test_extend_list_extends():
+    lst = [1, 2]
+    result = extend_list(lst, 5)
+    assert result == [1, 2, 2, 2, 2]
+
+
+def test_extend_list_no_op_when_already_long():
+    lst = [1, 2, 3]
+    result = extend_list(lst, 2)
+    assert result == [1, 2, 3]
+
+
+def test_extend_list_returns_same_object():
+    lst = [1, 2]
+    result = extend_list(lst, 4)
+    assert result is lst
+
+
+# ---- get_as_list ----
+
+def test_get_as_list_scalar_becomes_list():
+    assert get_as_list({"a": 3}, "a") == [3]
+
+
+def test_get_as_list_list_unchanged():
+    assert get_as_list({"a": [1, 2]}, "a") == [1, 2]
+
+
+def test_get_as_list_uses_default():
+    assert get_as_list({}, "a", default=7) == [7]
+
+
+def test_get_as_list_extendto():
+    assert get_as_list({"a": 5}, "a", extendto=3) == [5, 5, 5]
+
+
+def test_get_as_list_missing_no_default_raises():
+    with pytest.raises(KeyError):
+        get_as_list({}, "a")

--- a/test/tool/test_wavevector.py
+++ b/test/tool/test_wavevector.py
@@ -1,0 +1,54 @@
+import pytest
+import numpy as np
+
+from dsqss.wavevector import Wavevector
+
+
+# ---- generate ----
+
+def test_generate_1d_shape():
+    wv = Wavevector()
+    wv.generate({}, [4])
+    # steps = 4//2 = 2; range(0, 3, 2) = [0, 2] → nk=2
+    assert wv.dim == 1
+    assert wv.nk == 2
+    assert wv.ks.shape == (1, 2)
+
+
+def test_generate_2d_shape():
+    wv = Wavevector()
+    wv.generate({}, [4, 4])
+    # per dim: nk=2; total = 2*2 = 4
+    assert wv.dim == 2
+    assert wv.nk == 4
+    assert wv.ks.shape == (2, 4)
+
+
+def test_generate_custom_ksteps():
+    wv = Wavevector()
+    # ksteps=2, size=8: range(0, 5, 2) = [0,2,4] → nk=3
+    wv.generate({"ksteps": 2}, [8])
+    assert wv.nk == 3
+
+
+def test_generate_k_zero_always_present():
+    wv = Wavevector()
+    wv.generate({}, [4, 4])
+    # first k-point (ik=0) must be (0,0)
+    assert list(wv.ks[:, 0]) == [0, 0]
+
+
+# ---- save / load roundtrip ----
+
+def test_save_load_roundtrip(tmp_path):
+    wv = Wavevector()
+    wv.generate({}, [6])
+    path = str(tmp_path / "kpoints.dat")
+    wv.save(path)
+
+    wv2 = Wavevector()
+    wv2.load(path)
+
+    assert wv2.dim == wv.dim
+    assert wv2.nk == wv.nk
+    np.testing.assert_array_equal(wv2.ks, wv.ks)

--- a/test/tool/test_wavevector.py
+++ b/test/tool/test_wavevector.py
@@ -38,6 +38,23 @@ def test_generate_k_zero_always_present():
     assert list(wv.ks[:, 0]) == [0, 0]
 
 
+def test_generate_size_one_dim():
+    # size 1 along a dimension used to give steps=0 and
+    # "range() arg 3 must not be zero"; only k=0 exists there
+    wv = Wavevector()
+    wv.generate({}, [1])
+    assert wv.nk == 1
+    assert list(wv.ks[:, 0]) == [0]
+
+
+def test_generate_mixed_size_with_one():
+    wv = Wavevector()
+    wv.generate({}, [4, 1])
+    # dim 0 contributes k=0,2 (2 points), dim 1 only k=0
+    assert wv.nk == 2
+    assert all(wv.ks[1, :] == 0)
+
+
 # ---- save / load roundtrip ----
 
 def test_save_load_roundtrip(tmp_path):

--- a/tool/dsqss/algorithm.py
+++ b/tool/dsqss/algorithm.py
@@ -233,6 +233,12 @@ class AlgInteraction:
 
         self.hamint = hamint
         self.sites = [hamsites[stype] for stype in hamint.stypes]
+        for stype, site in zip(hamint.stypes, self.sites):
+            if site.N < 1:
+                raise ValueError(
+                    f"site type {stype} in interaction {hamint.itype} has no "
+                    f"states (N={site.N}); each site needs at least one state"
+                )
         self.sitesources = [deepcopy(site.sources) for site in self.sites]
         self.intelements = deepcopy(hamint.elements)
         self.ebase_negsign = float("inf")

--- a/tool/dsqss/algorithm.py
+++ b/tool/dsqss/algorithm.py
@@ -329,7 +329,7 @@ class AlgInteraction:
         midstates = [list(states[0]), list(states[1])]
         midstates[intau][insite] = instate
 
-        incomeindex = 100000  # very large integer
+        incomeindex = -1  # set when the incoming channel is found below
         probs = []
         outlegs = []
         outstates = []
@@ -362,6 +362,7 @@ class AlgInteraction:
                     incomeindex = len(probs) - 1
         if len(probs) == 0:
             return None
+        assert incomeindex >= 0, "incoming channel not found among candidates"
         W = self.kernel(probs)[incomeindex, :]
         channels = [
             Channel(outleg=outleg, state=outstate, prob=p)

--- a/tool/dsqss/displacement.py
+++ b/tool/dsqss/displacement.py
@@ -41,12 +41,12 @@ class Displacement:
             for t in range(lat.nsites):
                 dr = np.array(lat.sites[t].coord) - sr
                 for d in range(lat.dim):
-                    if lat.bc[d] == 1 and dr[d] <= -lat.size[d] // 2:
+                    if lat.bc[d] and dr[d] <= -lat.size[d] // 2:
                         dr[d] += lat.size[d]
-                    elif lat.bc[d] == 1 and dr[d] > lat.size[d] // 2:
+                    elif lat.bc[d] and dr[d] > lat.size[d] // 2:
                         dr[d] -= lat.size[d]
                 if distance_only:
-                    r = sum(map(lambda x: x * x, np.dot(lat.latvec, dr)))
+                    r = float(np.sum(np.dot(lat.latvec, dr) ** 2))
                 else:
                     r = tuple(dr)
                 if r not in rdict:

--- a/tool/dsqss/hamiltonian.py
+++ b/tool/dsqss/hamiltonian.py
@@ -223,21 +223,37 @@ class Hamiltonian:
         sites: List[Optional[Site]] = [None for i in range(self.nstypes)]
         for site in ham_dict["sites"]:
             S = Site(site)
+            if not 0 <= S.id < self.nstypes:
+                raise RuntimeError(
+                    f"site type {S.id} is out of range: "
+                    f"site types must cover 0..{self.nstypes - 1}"
+                )
             sites[S.id] = S
-        for site in sites:
+        for i, site in enumerate(sites):
             if site is None:
-                raise RuntimeError("")
+                raise RuntimeError(
+                    f"site type {i} is not defined: "
+                    f"site types must cover 0..{self.nstypes - 1} without gaps"
+                )
         self.sites = typing.cast(List[Site], sites)
 
         self.nitypes = len(ham_dict["interactions"])
         interactions: List[Optional[Interaction]] = [None for i in range(self.nitypes)]
         for inter in ham_dict["interactions"]:
             Int = Interaction(inter)
+            if not 0 <= Int.id < self.nitypes:
+                raise RuntimeError(
+                    f"interaction type {Int.id} is out of range: interaction "
+                    f"types must cover 0..{self.nitypes - 1}"
+                )
             interactions[Int.id] = Int
 
-        for inter in interactions:
+        for i, inter in enumerate(interactions):
             if inter is None:
-                raise RuntimeError("")
+                raise RuntimeError(
+                    f"interaction type {i} is not defined: interaction types "
+                    f"must cover 0..{self.nitypes - 1} without gaps"
+                )
         self.interactions = typing.cast(List[Interaction], interactions)
 
         self.nxmax = 0

--- a/tool/dsqss/lattice.py
+++ b/tool/dsqss/lattice.py
@@ -262,8 +262,10 @@ class Lattice:
         return ret, edge
 
     def save_dat(self, filename: util.Filename) -> None:
-        out = open(filename, "w", encoding="utf-8")
+        with open(filename, "w", encoding="utf-8") as out:
+            self._save_dat_impl(out)
 
+    def _save_dat_impl(self, out) -> None:
         out.write("name\n")
         out.write(f"{self.name}\n")
         out.write("\n")
@@ -305,12 +307,13 @@ class Lattice:
         out.write("# id, type, nbody, sites..., edge_flag, direction\n")
         for inter in self.ints:
             out.write(f"{inter}\n")
-        out.close()
         # end of save_dat
 
     def load_dat(self, filename: util.Filename) -> None:
-        inp = open(filename)
+        with open(filename) as inp:
+            self._load_dat_impl(inp)
 
+    def _load_dat_impl(self, inp) -> None:
         state = "waiting"
         count = 0
         self.dim = 0
@@ -428,7 +431,6 @@ class Lattice:
                     state = "waiting"
                     count = 0
         # end of for line in inp:
-        inp.close()
         self.check_all()
         self._update()
 

--- a/tool/dsqss/lattice.py
+++ b/tool/dsqss/lattice.py
@@ -347,7 +347,9 @@ class Lattice:
                         util.ERROR(f"too few elements ({body})")
                     else:
                         util.ERROR(f"too many elements ({body})")
-                self.bc = list(map(bool, elem))
+                # elem holds "0"/"1" strings; bool("0") is True, so convert
+                # via int to keep open boundaries open
+                self.bc = [bool(int(x)) for x in elem]
                 state = "latvec"
                 continue
             elif state == "latvec":

--- a/tool/dsqss/pmwa_pre.py
+++ b/tool/dsqss/pmwa_pre.py
@@ -154,31 +154,36 @@ class info:
                 tmp_dict[key] = d_re.group(2).strip()
         """
 
-        if tmp_dict["solver"] == "DLA":
+        solver = tmp_dict.get("solver")
+        if solver is None:
+            ERROR("solver is not specified in the input file")
+        elif solver == "DLA":
             ERROR("Please use dla_pre instead of pmwa_pre")
+        elif solver != "PMWA":
+            ERROR('unknown solver "{0}": pmwa_pre supports only PMWA'.format(solver))
+
+        self.prm.info_dict.update(self.prm.info_dict_pmwa)
+        self.prm.param_dict.update(self.prm.param_dict_pmwa)
+        # if oldbeta exits, add param_dict
+        if tmp_dict.get("oldbeta") is not None:
+            self.prm.param_dict["oldbeta"] = float(tmp_dict.get("oldbeta"))
+
+        # modify parameters for spin model
+        if "model_type" not in tmp_dict:
+            tmp_dict["model_type"] = self.prm.info_dict["model_type"]
+
+        if tmp_dict["model_type"] == "spin":
+            # assume that the lattice is bipartite
+            # this makes that t is always positive (by unitary transform)
+            if tmp_dict.get("jxy") is not None:
+                tmp_dict["jxy"] = abs(float(tmp_dict["jxy"]))
+            self._replace_keyword(tmp_dict, "t", "jxy")
+            self._replace_keyword(tmp_dict, "v", "jz")
+            self._replace_keyword(tmp_dict, "mu", "h")
+            self._replace_keyword(tmp_dict, "g", "gamma")
+            tmp_dict["g"] = float(tmp_dict["g"]) * 0.5
         else:
-            self.prm.info_dict.update(self.prm.info_dict_pmwa)
-            self.prm.param_dict.update(self.prm.param_dict_pmwa)
-            # if oldbeta exits, add param_dict
-            if tmp_dict.get("oldbeta") is not None:
-                self.prm.param_dict["oldbeta"] = float(tmp_dict.get("oldbeta"))
-
-            # modify parameters for spin model
-            if ("model_type" in tmp_dict) is False:
-                tmp_dict["model_type"] = self.prm.info_dict["model_type"]
-
-            if tmp_dict["model_type"] == "spin":
-                # assume that the lattice is bipartite
-                # this makes that t is always positive (by unitary transform)
-                if tmp_dict.get("jxy") is not None:
-                    tmp_dict["jxy"] = abs(float(tmp_dict["jxy"]))
-                self._replace_keyword(tmp_dict, "t", "jxy")
-                self._replace_keyword(tmp_dict, "v", "jz")
-                self._replace_keyword(tmp_dict, "mu", "h")
-                self._replace_keyword(tmp_dict, "g", "gamma")
-                tmp_dict["g"] = float(tmp_dict["g"]) * 0.5
-            else:
-                self._replace_keyword(tmp_dict, "g", "gamma")
+            self._replace_keyword(tmp_dict, "g", "gamma")
 
         self.param_list = list(self.prm.param_dict)
         self.param_list.sort()
@@ -234,8 +239,7 @@ class info:
             print("\n " + " ".join(cmd))
             subprocess.call(cmd)
         else:
-            msg = "pmwa_pre treats only PMWA."
-            sys.exit(1)
+            ERROR("pmwa_pre treats only PMWA.")
 
     def print_init_param(self):
         with open(self.args.pfile, mode="w") as f:

--- a/tool/dsqss/pmwa_pre.py
+++ b/tool/dsqss/pmwa_pre.py
@@ -136,23 +136,6 @@ class info:
 
     def _get_info(self, inputfile):
         tmp_dict = read_keyvalues(inputfile)
-        """
-        if inputfile is sys.stdin:
-            print('Waiting for standard input...')
-        data_list = inputfile.readlines()
-        tmp_dict={}
-        # get key and value
-        for data in data_list:
-            data.strip()
-            d_re = re.search("(.*)#(.*)", data)
-            if d_re is not None:
-                data = d_re.group(1)
-            pattern = "(.*)=(.*)"
-            if re.search(pattern,data) is not None:
-                d_re = re.search(pattern,data)
-                key = d_re.group(1).strip().lower()
-                tmp_dict[key] = d_re.group(2).strip()
-        """
 
         solver = tmp_dict.get("solver")
         if solver is None:

--- a/tool/dsqss/prob_kernel.py
+++ b/tool/dsqss/prob_kernel.py
@@ -23,6 +23,13 @@ class KernelCallBack(Protocol):
     def __call__(self, weights: Sequence[float], cutoff: float = ...) -> np.ndarray: ...
 
 
+def _normalize_rows(W: np.ndarray) -> None:
+    """Normalize each row of W to sum to 1, leaving all-zero rows
+    (states with zero weight) as zeros instead of producing NaN."""
+    rowsum = W.sum(axis=1).reshape(-1, 1)
+    np.divide(W, rowsum, out=W, where=rowsum > 0.0)
+
+
 def heat_bath(weights: Sequence[float], cutoff: float = 1e-10) -> np.ndarray:
     """
     return an array W,
@@ -72,16 +79,28 @@ def suwa_todo(weights: Sequence[float], cutoff: float = 1e-10) -> np.ndarray:
     """
 
     N = len(weights)
+    if N == 1:
+        return np.ones((1, 1))
     W = np.zeros((N, N))
     indices = np.argsort(weights, kind="mergesort")[::-1]
     target = [w for w in weights]
     for i in range(N):
         s = weights[indices[i]]
+        if s <= 0.0:
+            # this state is never occupied; leave its row zero
+            continue
         j = 1
         while target[indices[j]] == 0.0:
             j = (j + 1) % N
+            if j == 1:
+                # scanned a full cycle: no target capacity remains
+                break
         while s > 0.0:
             p = min(s, target[indices[j]])
+            if p <= 0.0:
+                # only rounding leftovers remain and no target can
+                # absorb them; drop the remainder instead of looping
+                break
             s -= p
             target[indices[j]] -= p
             W[indices[i], indices[j]] = p
@@ -90,9 +109,10 @@ def suwa_todo(weights: Sequence[float], cutoff: float = 1e-10) -> np.ndarray:
                 if j == i:
                     break
                 j = (j + 1) % N
-    W /= W.sum(axis=1).reshape(-1, 1)
+    _normalize_rows(W)
     W[W < cutoff] = 0.0
-    return W / W.sum(axis=1).reshape(-1, 1)
+    _normalize_rows(W)
+    return W
 
 
 def reversible_suwa_todo(weights: Sequence[float], cutoff: float = 1e-10) -> np.ndarray:
@@ -105,6 +125,8 @@ def reversible_suwa_todo(weights: Sequence[float], cutoff: float = 1e-10) -> np.
     """
     ws = np.array(weights)
     N = len(ws)
+    if N == 1:
+        return np.ones((1, 1))
     indices = np.argsort(ws, kind="mergesort")[::-1]
     ws = np.array(ws)
     W = np.zeros([N, N])
@@ -129,9 +151,10 @@ def reversible_suwa_todo(weights: Sequence[float], cutoff: float = 1e-10) -> np.
             v = W[jj, jj] / j
             for k in range(j - 1, -1, -1):
                 rst_swap(jj, indices[k], v, W)
-    W /= W.sum(axis=1).reshape(-1, 1)
+    _normalize_rows(W)
     W[W < cutoff] = 0.0
-    return W / W.sum(axis=1).reshape(-1, 1)
+    _normalize_rows(W)
+    return W
 
 
 def rst_swap(i: int, j: int, w: np.ndarray, W: np.ndarray) -> None:

--- a/tool/dsqss/read_keyvalues.py
+++ b/tool/dsqss/read_keyvalues.py
@@ -22,7 +22,7 @@ def read_keyvalues(inputfile):
     """
     read and eval `inputfile` and return a dictionary
     """
-    if type(inputfile) is str:
+    if isinstance(inputfile, str):
         with open(inputfile) as f:
             return read_keyvalues(f)
     if inputfile is sys.stdin:
@@ -31,7 +31,6 @@ def read_keyvalues(inputfile):
     res = {}
     # get key and value
     for data in data_list:
-        data.strip()
         d_re = re.search("(.*)#(.*)", data)
         if d_re is not None:
             data = d_re.group(1)
@@ -47,7 +46,7 @@ def read_keyvalues(inputfile):
 
 
 def parse_list(lst, N, typ=None):
-    if type(lst) is not list:
+    if not isinstance(lst, list):
         ret = [lst]
     else:
         ret = lst[:]

--- a/tool/dsqss/result.py
+++ b/tool/dsqss/result.py
@@ -39,7 +39,7 @@ class Results:
                 self.result[words[1]] = R
 
     def to_str(self, names, delim=" ", delim_data=" "):
-        if type(names) is str:
+        if isinstance(names, str):
             return self.result[names].to_str(delim)
         ss = [self.result[name].to_str(delim) for name in names]
         return delim_data.join(ss)

--- a/tool/dsqss/util.py
+++ b/tool/dsqss/util.py
@@ -24,8 +24,13 @@ Filename = Union[str, bytes, os.PathLike]
 
 
 def LOG_IMPL(
-    msg: str, typ: str, to_be_continued: bool, linebreak: bool, file: TextIO
+    msg: str, typ: str, to_be_continued: bool, linebreak: bool,
+    file: Optional[TextIO],
 ) -> None:
+    # file=None resolves to sys.stderr at call time; binding it as a
+    # default argument would freeze the stream captured at import time
+    if file is None:
+        file = sys.stderr
     print(f"{typ}: {msg}\n", file=file)
     if linebreak:
         print("\n", file=file)
@@ -33,11 +38,11 @@ def LOG_IMPL(
         sys.exit(1)
 
 
-def INFO(msg: str, linebreak: bool = True, file: TextIO = sys.stderr) -> None:
+def INFO(msg: str, linebreak: bool = True, file: Optional[TextIO] = None) -> None:
     LOG_IMPL(msg, "INFO", linebreak=linebreak, to_be_continued=True, file=file)
 
 
-def WARN(msg: str, linebreak: bool = True, file: TextIO = sys.stderr) -> None:
+def WARN(msg: str, linebreak: bool = True, file: Optional[TextIO] = None) -> None:
     LOG_IMPL(msg, "WARN", linebreak=linebreak, to_be_continued=True, file=file)
 
 
@@ -45,12 +50,11 @@ def ERROR(
     msg: str,
     to_be_continued: bool = False,
     linebreak: bool = True,
-    file: TextIO = sys.stderr,
+    file: Optional[TextIO] = None,
 ):
     LOG_IMPL(
         msg, "ERROR", linebreak=linebreak, to_be_continued=to_be_continued, file=file
     )
-    pass
 
 
 def extend_list(lst: List, N: int) -> List:

--- a/tool/dsqss/wavevector.py
+++ b/tool/dsqss/wavevector.py
@@ -52,7 +52,10 @@ class Wavevector:
             self.ks[:, ik] = list(k)
 
     def load(self, filename: dsqss.util.Filename) -> None:
-        inp = open(filename, encoding="utf-8")
+        with open(filename, encoding="utf-8") as inp:
+            self._load_impl(inp)
+
+    def _load_impl(self, inp) -> None:
         self.dim = 0
         state = "waiting"
         for line in inp:
@@ -88,11 +91,12 @@ class Wavevector:
                 words = body.split()
                 kid = int(words[0])
                 self.ks[:, kid] = list(map(int, words[1:]))
-        inp.close()
 
     def save(self, filename: dsqss.util.Filename) -> None:
-        out = open(filename, "w", encoding="utf-8")
+        with open(filename, "w", encoding="utf-8") as out:
+            self._save_impl(out)
 
+    def _save_impl(self, out) -> None:
         out.write("dim\n{0}\n".format(self.dim))
         out.write("\n")
 
@@ -103,7 +107,6 @@ class Wavevector:
             for k in self.ks[:, ik]:
                 out.write(" {0}".format(k))
             out.write("\n")
-        out.close()
 
     def write_xml(self, filename: dsqss.util.Filename, lat: dsqss.lattice.Lattice):
         tagged = dsqss.util.tagged

--- a/tool/dsqss/wavevector.py
+++ b/tool/dsqss/wavevector.py
@@ -38,6 +38,10 @@ class Wavevector:
         for d in range(self.dim):
             if steps[d] == 0:
                 steps[d] = size[d] // 2
+            if steps[d] == 0:
+                # size[d] == 1: only k=0 exists along this dimension;
+                # any positive step keeps range() valid
+                steps[d] = 1
         ks = []
         self.nk = 1
         for d in range(self.dim):


### PR DESCRIPTION
## Summary

This PR adds a pytest-based unit-test suite for the `tool/dsqss` Python package
(previously covered only by three golden-file integration tests) and fixes the
bugs the accompanying code review uncovered. All work is topic-per-commit; each
bug fix was reproduced with a failing test first.

**Final state: 185 tests passed, 0 xfail** (starting point: 168 passed, 3 known
bugs recorded as `xfail(strict=True)`).

## Test infrastructure

- New unit tests for `util`, `read_keyvalues`, `prob_kernel`, `parameter`,
  `result`, `lattice_factory`, `lattice`, `hamiltonian`, `displacement`,
  `wavevector`, `algorithm`, and `pmwa_pre` (~190 tests), with shared fixtures
  in `conftest.py` that build small lattices/Hamiltonians without file I/O.
- `test/tool` now runs through `python -m pytest` from ctest; the existing
  `unittest`-based integration tests are unchanged and keep working.
- CI installs `pytest` alongside the other Python dependencies.

## Bug fixes

| Commit | Fix |
|---|---|
| 5a7cf2b | `Lattice.load_dat` turned open boundary conditions into periodic ones: `bool("0")` is `True` in Python, so a lattice saved with `bc = [False]` was silently loaded back as periodic and downstream consumers (e.g. `Displacement`) applied wrong wrapping. **This is a behavior change in the direction of correctness** — results obtained by loading open-boundary `.dat` files were affected. |
| da35a21 | `suwa_todo` crashed with `IndexError` for a single-element weight list and hung forever when exactly one weight was nonzero; row normalization produced NaN rows for zero-weight states. `reversible_suwa_todo` had the same single-element bug. For strictly positive weights — the only inputs produced by `dsqss.algorithm` — the output is unchanged (generated `algorithm.xml` is byte-identical). |
| 1c35b5f | `Wavevector.generate` raised `range() arg 3 must not be zero` when any dimension has linear size 1. |
| 30ee414 | `Hamiltonian` raised `RuntimeError("")` (empty message) on gaps in site/interaction type ids, and a bare `IndexError` on out-of-range ids; both now report the offending id and expected range. |
| 5a2b70e | `AlgInteraction` divided by zero when a site had no states; now rejected up front with a clear `ValueError`. |
| 65427af | `pmwa_pre` crashed with a raw `KeyError` when the input file had no `solver` line, and a mistyped solver value slipped through the parser and exited without printing anything. Both paths now produce clear error messages. Also makes the `util.py` log helpers resolve `sys.stderr` at call time instead of freezing it as a default argument. |
| d686e73 | Behavior-preserving cleanups: context managers for file I/O in `lattice`/`wavevector`, magic sentinel `incomeindex = 100000` replaced by `-1` + assertion, `isinstance` instead of `type() is`, dead-code removal. |

## Verification

- Every fix landed with a test that failed before the change (or flipped a
  strict `xfail` to pass, which the suite detects as XPASS).
- Generator outputs (`param.in`, `lattice.xml`, `algorithm.xml`) were compared
  byte-for-byte against pre-change golden files for both `dla_pre` and
  `pmwa_pre`; the only intended differences are the bug fixes listed above.

## Compatibility note

The `load_dat` boundary-condition fix changes results for workflows that load
open-boundary lattice `.dat` files (they were previously simulated as
periodic). This should be mentioned in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)