### PR TITLE
Fix memory-safety, correctness, and robustness issues in the dla and pmwa cores

### DIFF
--- a/src/dla/algorithm.hpp
+++ b/src/dla/algorithm.hpp
@@ -767,20 +767,29 @@ void VertexInitialConfiguration::initialize(XML::Block& X) {  // <initialconfig>
   INC = X["IncomingDirection"].getInteger();
   XINC = X["NewState"].getInteger();
   NCH = X["NumberOfChannels"].getInteger();
+  if (NCH < 1) {
+    printf("VertexInitialConfiguration::initialize> Error.\n");
+    printf("  NumberOfChannels (=%d) must be positive.\n", NCH);
+    exit(1);
+  }
 
-  MCH = 4;
+  MCH = NCH;
   CH.init("VCH", 1, MCH);
 
   int ch = 0;
   for (int i = 0; i < X.NumberOfBlocks(); i++) {
     XML::Block& B = X[i];
-    if (B.getName() == "Channel") CH[ch++].initialize(B);
+    if (B.getName() == "Channel") {
+      if (ch < MCH) CH[ch].initialize(B);
+      ch++;
+    }
   }
 
   if (ch != NCH) {
-    printf("SiteInitialConfiguration::initialize> Error.\n");
+    printf("VertexInitialConfiguration::initialize> Error.\n");
     printf("  The actual number of channels (=%d)\n", ch);
     printf("  does not agree with NCH (=%d)\n", NCH);
+    exit(1);
   }
 }
 

--- a/src/dla/chainjob.hpp
+++ b/src/dla/chainjob.hpp
@@ -18,6 +18,7 @@
 #define SRC_DLA_CHAINJOB_HPP_
 
 // BINARY FILE
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <map>
@@ -49,7 +50,11 @@ void Simulation::BinaryIO() {
 
 void Simulation::save() {
   using Serialize::save;
-  cjobout.open(CJOBFILE.c_str(), std::ios::out | std::ios::binary);
+  // Write to a temporary file and rename over the previous checkpoint
+  // only after a successful write, so that a crash during save() cannot
+  // destroy the only existing checkpoint.
+  const std::string tmpfile = CJOBFILE + ".tmp";
+  cjobout.open(tmpfile.c_str(), std::ios::out | std::ios::binary);
 
   save(cjobout, isEnd);
   save(cjobout, P.NCYC);
@@ -155,7 +160,19 @@ void Simulation::save() {
   cf.save(cjobout);
   ck.save(cjobout);
 
+  cjobout.flush();
+  if (!cjobout) {
+    std::cout << "ERROR: failed to write checkpoint file " << tmpfile
+              << "; keeping the previous checkpoint." << std::endl;
+    cjobout.close();
+    std::remove(tmpfile.c_str());
+    return;
+  }
   cjobout.close();
+  if (std::rename(tmpfile.c_str(), CJOBFILE.c_str()) != 0) {
+    std::cout << "ERROR: failed to replace checkpoint file " << CJOBFILE
+              << std::endl;
+  }
 }
 
 void Simulation::load() {
@@ -174,7 +191,6 @@ void Simulation::load() {
                  "setting Ncycle"
               << std::endl;
     cjobin.close();
-    cjobout.open(CJOBFILE.c_str(), std::ios::out | std::ios::binary);
     end_cjob();
   }
 
@@ -250,8 +266,13 @@ void Simulation::load() {
       }
       for (int leg = 0; leg < NLEG_; leg++) {
         int SID_ = load<int>(cjobin);
-        Segment *findingS = (oldID_S.find(SID_))->second;
-        V.setS(leg, (*findingS));
+        std::map<int, Segment *>::iterator sit = oldID_S.find(SID_);
+        if (sit == oldID_S.end()) {
+          std::cout << "ERROR: broken checkpoint (unknown segment ID " << SID_
+                    << ")." << std::endl;
+          end_job();
+        }
+        V.setS(leg, *(sit->second));
       }
       ++NVER_count;
     }
@@ -278,8 +299,13 @@ void Simulation::load() {
     int NLEG_ = load<int>(cjobin);
     for (int leg = 0; leg < NLEG_; leg++) {
       int SID_ = load<int>(cjobin);
-      Segment *findingS = (oldID_S.find(SID_))->second;
-      V.setS(leg, (*findingS));
+      std::map<int, Segment *>::iterator sit = oldID_S.find(SID_);
+      if (sit == oldID_S.end()) {
+        std::cout << "ERROR: broken checkpoint (unknown segment ID " << SID_
+                  << ")." << std::endl;
+        end_job();
+      }
+      V.setS(leg, *(sit->second));
     }
     ++NVER_count;
   }  // terminal vertices
@@ -295,10 +321,16 @@ void Simulation::load() {
       Segment &S = *itp;
       int VID_0 = (newID2V.find(S.id())->second).first;
       int VID_1 = (newID2V.find(S.id())->second).second;
-      Vertex *V0 = (oldID_V.find(VID_0))->second;
-      Vertex *V1 = (oldID_V.find(VID_1))->second;
-      S.BareSegment::setBottom((*V0));
-      S.BareSegment::setTop((*V1));
+      std::map<int, Vertex *>::iterator vit0 = oldID_V.find(VID_0);
+      std::map<int, Vertex *>::iterator vit1 = oldID_V.find(VID_1);
+      if (vit0 == oldID_V.end() || vit1 == oldID_V.end()) {
+        std::cout << "ERROR: broken checkpoint (unknown vertex ID "
+                  << (vit0 == oldID_V.end() ? VID_0 : VID_1) << ")."
+                  << std::endl;
+        end_job();
+      }
+      S.BareSegment::setBottom(*(vit0->second));
+      S.BareSegment::setTop(*(vit1->second));
     }
   }
 
@@ -320,9 +352,11 @@ void Simulation::load() {
 
 void Simulation::end_cjob() {
   cjobout.close();
-  cjobout.open(CJOBFILE.c_str(), std::ios::out | std::ios::binary);  // reset
+  const std::string tmpfile = CJOBFILE + ".tmp";
+  cjobout.open(tmpfile.c_str(), std::ios::out | std::ios::binary);  // reset
   Serialize::save(cjobout, isEnd);
   cjobout.close();
+  std::rename(tmpfile.c_str(), CJOBFILE.c_str());
   std::cout << "Save checkpoint file and stop the simulation." << std::endl;
   end_job();
 }

--- a/src/dla/dla.cc
+++ b/src/dla/dla.cc
@@ -208,6 +208,26 @@ Simulation::Simulation(Parameter& P0)
   }
 }
 
+bool Simulation::simtime_exceeded() {
+  int expired = (cjob_timer.elapsed() > P.SIMTIME) ? 1 : 0;
+#ifdef MULTI
+  // All ranks must agree on the timeout decision: otherwise one rank
+  // enters save()/end_job() (MPI_Barrier) while another continues into
+  // the final allreduce -- mismatched collectives and a permanent hang.
+  // Every rank reaches this check at the same iteration when RUNTYPE == 0
+  // (all ranks share one parameter file); for RUNTYPE >= 3 each rank has
+  // its own parameters, so sweep counts may differ between ranks and a
+  // collective here would itself desynchronize -- keep the per-rank
+  // decision there, as before.
+  if (P.RUNTYPE == 0) {
+    int expired_any = expired;
+    MPI_Allreduce(&expired, &expired_any, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    expired = expired_any;
+  }
+#endif
+  return expired != 0;
+}
+
 void Simulation::reset_counters() {
   ISET = -1;
   IMCSE = -1;
@@ -258,7 +278,7 @@ void Simulation::Set(int ntherm, int nmcs) {
 
   for (IMCSD = IMCSDstart; IMCSD < ntherm; IMCSD++) {
     if (P.SIMTIME > 0) {
-      if (cjob_timer.elapsed() > P.SIMTIME) {
+      if (simtime_exceeded()) {
         IMCS = 0;
         save();
         end_job();
@@ -280,7 +300,7 @@ void Simulation::Set(int ntherm, int nmcs) {
 
   for (IMCS = IMCSstart; IMCS < nmcs; IMCS++) {
     if (P.SIMTIME > 0.0) {
-      if (cjob_timer.elapsed() > P.SIMTIME) {
+      if (simtime_exceeded()) {
         save();
         end_job();
       }

--- a/src/dla/dla.cc
+++ b/src/dla/dla.cc
@@ -522,6 +522,10 @@ double Simulation::UP_ONESTEP(bool thermalized) {
         int s_UI = 0;
         double iRHO = 0.0;
         double sRHO = 0.0;
+        // i_UI < NCI guards against walking past the array when RHORND
+        // reaches the total weight (RHO drifts from sum(dRHO) by rounding
+        // because it is updated incrementally); we then clamp to the last
+        // defined interval.
         do {
           sRHO = iRHO;
           if (UI[i_UI].DefinedVIC) {
@@ -529,7 +533,7 @@ double Simulation::UP_ONESTEP(bool thermalized) {
             s_UI = i_UI;
           }
           ++i_UI;
-        } while (RHORND >= iRHO);
+        } while (RHORND >= iRHO && i_UI < NCI);
         RHORND -= sRHO;
 
         UniformInterval& ui = UI[s_UI];
@@ -737,6 +741,7 @@ double Simulation::DOWN_ONESTEP(bool thermalized) {
         int s_UI = 0;
         double iRHO = 0.0;
         double sRHO = 0.0;
+        // see the corresponding comment in UP_ONESTEP
         do {
           sRHO = iRHO;
           if (UI[i_UI].DefinedVIC) {
@@ -744,7 +749,7 @@ double Simulation::DOWN_ONESTEP(bool thermalized) {
             s_UI = i_UI;
           }
           ++i_UI;
-        } while (RHORND >= iRHO);
+        } while (RHORND >= iRHO && i_UI < NCI);
         RHORND -= sRHO;
 
         UniformInterval& ui = UI[s_UI];

--- a/src/dla/dla.cc
+++ b/src/dla/dla.cc
@@ -227,6 +227,7 @@ void Simulation::set_NCYC() {
   double path;
   int ncyc = 1;
   int NSAMP = P.NPRE / 10;
+  if (NSAMP < 1) NSAMP = 1;
   std::vector<int> ncycSAMP(NSAMP);
 
   for (IMCSE = 0; IMCSE < P.NPRE; IMCSE++) {

--- a/src/dla/dla.hpp
+++ b/src/dla/dla.hpp
@@ -150,6 +150,7 @@ class Simulation {
   void save();
   void end_cjob();
   void end_job();
+  bool simtime_exceeded();
 };
 
 #endif  // DLA_HPP

--- a/src/dla/io.h
+++ b/src/dla/io.h
@@ -145,7 +145,7 @@ class FileReader {
   }
 
   std::string& word(int i) {
-    if (i < 0 && i >= NW) {
+    if (i < 0 || i >= NW) {
       std::string msg("FileReader::word> Invalid index ");
       msg += tostring(i);
       throw std::runtime_error(msg);

--- a/src/dla/lattice.hpp
+++ b/src/dla/lattice.hpp
@@ -142,6 +142,7 @@ void Lattice::read() {
   bool INIT_I = true;
   bool INIT_V = true;
   BD = -1;
+  NEDGE = 0;  // stays 0 when the lattice file has no edge columns
   edge = NULL;
   vec = NULL;
 

--- a/src/dla/measure.hpp
+++ b/src/dla/measure.hpp
@@ -258,7 +258,7 @@ inline void Measurement::dump() {
     ACC[i].show();
   }
   printf("\n");
-  for (int i = 0; i <= NPHY; i++) {
+  for (int i = 0; i < NPHY; i++) {
     printf("phy[%2d] : ", i);
     PHY[i].show();
   }

--- a/src/dla/objects.hpp
+++ b/src/dla/objects.hpp
@@ -565,8 +565,10 @@ inline bool BareVertex::isTail() const {
 //======================================================================
 
 inline int BareVertex::which(Segment& s) {
-  int i;
-  for (i = 0; i < 4; i++) {
+  // NLEG() is 2 for terminal vertices and 2*NBODY otherwise; a fixed
+  // bound of 4 read past _s for terminals and missed legs for NBODY > 2.
+  const int nleg = NLEG();
+  for (int i = 0; i < nleg; i++) {
     if (_s[i] == &s) return i;
   }
   printf("BareVertex::which> ERROR. No such segment.\n");

--- a/src/dla/parameter.hpp
+++ b/src/dla/parameter.hpp
@@ -210,7 +210,7 @@ void Parameter::init(std::map<std::string, std::string>& dict) {
   dict["seed"] = "198212240";
   dict["nvermax"] = "10000";
   dict["nsegmax"] = "10000";
-  dict["ntau"] = 10;
+  dict["ntau"] = "10";
   dict["algfile"] = "algorithm.xml";
   dict["latfile"] = "lattice.xml";
   dict["wvfile"] = "wavevector.xml";

--- a/src/dla/parameter.hpp
+++ b/src/dla/parameter.hpp
@@ -136,6 +136,9 @@ void Parameter::readfile(std::string const& filename) {
   NMCS = lexical_cast<int>(dict["nmcs"]);
   NTHERM = lexical_cast<int>(dict["ntherm"]);
   NPRE = lexical_cast<int>(dict["npre"]);
+  if (NPRE < 1) {
+    util::ERROR("\"npre\" must be a positive integer.");
+  }
   if (dict.find("ndecor") != dict.end()) {
     NDECOR = lexical_cast<int>(dict["ndecor"]);
   } else {

--- a/src/dla/serialize.hpp
+++ b/src/dla/serialize.hpp
@@ -17,6 +17,8 @@
 #ifndef SRC_DLA_SERIALIZE_HPP_
 #define SRC_DLA_SERIALIZE_HPP_
 
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 #include <fstream>
@@ -33,6 +35,12 @@ void save(std::ofstream& ofs, const T& val) {
 template <class T>
 void load(std::ifstream& ifs, T& val) {
   ifs.read(reinterpret_cast<char*>(&val), sizeof(T));
+  if (!ifs) {
+    std::fprintf(stderr,
+                 "ERROR: failed to read a value from the checkpoint file "
+                 "(truncated or corrupted).\n");
+    std::exit(1);
+  }
 }
 template <class T>
 T load(std::ifstream& ifs) {

--- a/src/pmwa/PMWA.cpp
+++ b/src/pmwa/PMWA.cpp
@@ -38,6 +38,14 @@ Dla::Dla(int NP, char **PLIST) {
   MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
   MPI_Comm_size(MPI_COMM_WORLD, &p_num);
 
+  if (NP < 2) {
+    if (my_rank == 0) {
+      std::cerr << "usage: " << PLIST[0] << " parameter_file" << std::endl;
+    }
+    MPI_Finalize();
+    std::exit(1);
+  }
+
   std::stringstream logfile;
   logfile << PLIST[1] << "." << my_rank << ".log";
 

--- a/src/pmwa/graphspace.cpp
+++ b/src/pmwa/graphspace.cpp
@@ -877,7 +877,10 @@ int GraphSpace::NumberOfVertex(My_rdm *MR, double m, int py) {
   double R = MR->rdm();
   double POW, EXP;
   POW = (n) ? m : 1.0;
-  int FAC = 1;
+  // FAC accumulates the double factorial of n; as an int it overflowed
+  // (undefined behavior) around n = 20, corrupting the distribution and
+  // potentially never satisfying the exit condition.
+  double FAC = 1.0;
   EXP = (this->*fmath[py])(m);
 
   while (1) {
@@ -888,11 +891,16 @@ int GraphSpace::NumberOfVertex(My_rdm *MR, double m, int py) {
 
     if (R < Pn / EXP) {
       return n;
-    } else {
-      n += 2;
-      fn = n;
-      POW *= m * m;
     }
+    if (pos == 0.0) {
+      // The series terms have underflowed: the remaining tail mass is
+      // not representable, so R cannot be reached anymore. Return the
+      // current n instead of looping forever.
+      return n;
+    }
+    n += 2;
+    fn = n;
+    POW *= m * m;
   }
 }
 

--- a/src/pmwa/graphspace.cpp
+++ b/src/pmwa/graphspace.cpp
@@ -206,14 +206,14 @@ void GraphSpace::initialev(std::string const &Eventfile_old, My_rdm *MR, int cb,
 
         new_event_L.i = xl;
         connect_before(w[(xl % V)], &(new_event_L));
-        ev.push_back(new_event_L);
+        push_event(new_event_L);
         reuse_L = &(ev.back());
         connect_after(w, &(ev.back()), xl % V);
 
         if (new_event_L.type == 2) {
           new_event_R.i = xr;
           connect_before(w[(xr % V)], &(new_event_R));
-          ev.push_back(new_event_R);
+          push_event(new_event_R);
           reuse_R = &(ev.back());
           connect_after(w, &(ev.back()), xr % V);
 
@@ -670,6 +670,19 @@ void GraphSpace::insert(Vertex *v, short new_type, double new_time, int x,
     Renew_Vertex(v, new_type, new_time, x, p, d);
 }
 
+GraphSpace::Vertex &GraphSpace::push_event(const Vertex &new_event) {
+  if (ev.size() >= static_cast<size_t>(IMAX)) {
+    cout << "ERROR: rank " << my_rank
+         << ": the number of vertices reached nvermax (=" << IMAX
+         << "). Growing the event buffer would invalidate all worldline "
+            "links. Increase nvermax."
+         << endl;
+    exit(1);
+  }
+  ev.push_back(new_event);
+  return ev.back();
+}
+
 void GraphSpace::insert_NewEvent(Vertex *v, int new_type, double new_time,
                                  int xx, int px, int d) {
   Vertex new_event;
@@ -679,7 +692,7 @@ void GraphSpace::insert_NewEvent(Vertex *v, int new_type, double new_time,
   new_event.i = xx + d * V;
   new_event.p = px;
 
-  ev.push_back(new_event);
+  push_event(new_event);
 
   relink(v, &(ev.back()), v->next[1]);
 }
@@ -808,6 +821,13 @@ void GraphSpace::parity_check(My_rdm *MR, int py, double *x, int &j,
   double Ia = Il * P->rh_even;
 
   j = (Ia == 0.0) ? 0 : NumberOfVertex(MR, Ia, py);
+
+  if (j > WMAX) {
+    cout << "ERROR: rank " << my_rank
+         << ": the number of worms in a segment (=" << j
+         << ") exceeds nwormax (=" << WMAX << "). Increase nwormax." << endl;
+    exit(1);
+  }
 
   if (j != 0) {
     if (Il <= (j + 1) * NMIN) {

--- a/src/pmwa/graphspace.cpp
+++ b/src/pmwa/graphspace.cpp
@@ -192,16 +192,27 @@ void GraphSpace::initialev(std::string const &Eventfile_old, My_rdm *MR, int cb,
       fin >> Ncyc;
       for (int i = 0; i < V; i++) fin >> world[i].p >> worldB[i].p;
 
-      while (!fin.eof()) {
-        fin >> dummy >> new_event_L.t >> new_event_L.type >> new_event_L.p >>
-            xl;
-        if (new_event_L.type == 2)
-          fin >> dummy >> new_event_R.t >> new_event_R.type >> new_event_R.p >>
-              xr;
+      // Loop on successful extraction: testing eof() before reading
+      // injected one extra bogus event built from failed extractions.
+      while (fin >> dummy >> new_event_L.t >> new_event_L.type >>
+             new_event_L.p >> xl) {
+        if (new_event_L.type == 2) {
+          if (!(fin >> dummy >> new_event_R.t >> new_event_R.type >>
+                new_event_R.p >> xr)) {
+            if (PR->my_rank == 0) {
+              cerr << "ERROR: event file is truncated: a two-site vertex "
+                      "is missing its partner record."
+                   << endl;
+            }
+            fin.close();
+            MPI_Finalize();
+            exit(1);
+          }
+        }
 
         if (PR->FlgAnneal) {
           new_event_L.t *= B / oldB;
-          new_event_R.t *= B / oldB;
+          if (new_event_L.type == 2) new_event_R.t *= B / oldB;
         }
 
         new_event_L.i = xl;
@@ -329,6 +340,11 @@ void GraphSpace::Output(std::string const &fname, My_rdm *MR) {
     i++;
   }
 
+  file.flush();
+  if (!file) {
+    cerr << "ERROR: rank " << my_rank << ": failed to write event file "
+         << fname << endl;
+  }
   file.close();
 
   std::string rndfile("RND");

--- a/src/pmwa/inc/Configuration.h
+++ b/src/pmwa/inc/Configuration.h
@@ -243,6 +243,10 @@ class GraphSpace {
   void insert_NewEvent(Vertex *v, int new_type, double new_time, int xx, int px,
                        int d);
 
+  // push_back into ev with a capacity check: ev must never reallocate
+  // because the worldline linked lists hold raw pointers into its buffer.
+  Vertex &push_event(const Vertex &new_event);
+
   void Renew_Vertex(Vertex *v, int new_type, double new_time, int xx, int px,
                     int d);
 

--- a/src/pmwa/inc/xml.hpp
+++ b/src/pmwa/inc/xml.hpp
@@ -69,7 +69,7 @@ class FileReader {
   }
 
   std::string &word(int i) {
-    if (i < 0 && i >= NW) {
+    if (i < 0 || i >= NW) {
       printf("FileReader::word> Error.\n");
       exit(0);
     }

--- a/src/pmwa/lattice.cpp
+++ b/src/pmwa/lattice.cpp
@@ -1,5 +1,7 @@
 #include <lattice.hpp>
 
+#include "mpi.h"
+
 namespace ARRAY {
 int EOL = -1;
 }
@@ -450,6 +452,17 @@ void Lattice::make_Parallel(Parallel *_PR) {
       PR->Ntdiv *
       PR->Nsdiv;  // the number of decompositions (non-trivial parallelization).
   PR->Npara = PR->p_num / PR->NtNs;  // the number of trivial parallelization.
+
+  if (PR->Npara < 1 || PR->p_num % PR->NtNs != 0) {
+    if (PR->my_rank == 0) {
+      std::cerr << "ERROR: the number of MPI processes (" << PR->p_num
+                << ") must be a positive multiple of the number of domains "
+                   "(NLdiv^d * NBdiv = "
+                << PR->NtNs << " for this lattice file)." << std::endl;
+    }
+    MPI_Finalize();
+    exit(1);
+  }
 
   PR->nt =
       PR->my_rank % PR->Ntdiv;  // the temporal domain number for the processor.

--- a/src/pmwa/quantities.B.cpp
+++ b/src/pmwa/quantities.B.cpp
@@ -509,6 +509,10 @@ void Quantities::WindingNumber2() {
 
 void Quantities::Density(GraphSpace::Vertex *world,
                          GraphSpace::Vertex *worldB) {
+  // sublattice sign for staggered quantities (lx[i] is the sublattice
+  // index 0/1); multiplying by lx[i] itself summed over one sublattice
+  // only, unlike the spin variant (quantities.H.cpp).
+  double ph[2] = {1.0, -1.0};
   double atot = 0.0, btot = 0.0, stot = 0.0, xtot = 0.0;
 
   for (int i = 0; i < V; i++) {
@@ -525,8 +529,8 @@ void Quantities::Density(GraphSpace::Vertex *world,
     double a0 = world[i].p;
     atot += a0;
 
-    stot += a0 * LT->lx[i];
-    xtot += values_L[f_ld(i)] * LT->lx[i];
+    stot += a0 * ph[LT->lx[i]];
+    xtot += values_L[f_ld(i)] * ph[LT->lx[i]];
   }
 
   values_S[bmzu] = btot;


### PR DESCRIPTION
## Summary

Fixes a series of bugs in `src/dla` and `src/pmwa` found during a code
review: out-of-bounds accesses (confirmed with ASan), crashes on unusual
input, a physics bug in pmwa_B, unsafe checkpointing, and an MPI hang
window. One commit per topic.

## dla

- `ntau` default was the character `'\n'` instead of `"10"` (crash when
  `ntau` is omitted); SIGFPE for `npre < 10`.
- Out-of-bounds accesses: unbounded interaction-selection scan in the worm
  update; hard-coded 4-leg assumptions in `BareVertex::which()` and the
  channel array (2-leg / NBODY ≥ 3 vertices).
- Crash-safe checkpointing: write to temp + rename, validate all reads on
  restore (a kill during save no longer destroys the only checkpoint).
- `simulationtime` timeout is now a collective decision, removing a
  mismatched-collectives hang at the deadline (verified with a 2-rank chain
  job across 29 restarts).

## pmwa

- Exceeding `nvermax`/`nwormax` silently corrupted memory (vector
  reallocation dangles all worldline pointers); now hard errors.
- Restart loader: `while (!eof())` injected a bogus event; uninitialized
  reads for the first record; truncated files now abort cleanly.
- pmwa_B `smzs`/`xmzs` were wrong: multiplied by sublattice index (0/1)
  instead of sign (±1). The spin variant already had the fix. Values change
  (release-note item); non-staggered observables are bit-identical.
- `int` overflow in `NumberOfVertex` (double factorial, reachable at
  moderate beta*gamma); missing argv/MPI-process-count validation.

## Verification

Fixed-seed reference runs (dla and pmwa_H) are bit-identical after every
behavior-preserving commit; each bug was reproduced before fixing; ASan-clean;
multi-rank checks done with real `mpirun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)