### PR TITLE
Modernize the build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,15 @@
-cmake_minimum_required(VERSION 2.8.12...3.20.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.1...3.20.2 FATAL_ERROR)
 project(DSQSS NONE)
 set(DSQSS_VERSION 2.1-dev)
 
 message(STATUS "CMake version: " ${CMAKE_VERSION})
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address -fomit-frame-pointer")
+# AddressSanitizer needs the frame pointer kept for usable stack traces
+set(CMAKE_CXX_FLAGS_DEBUG "-g -fsanitize=address -fno-omit-frame-pointer")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG "-fsanitize=address")
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CONFIG)    
   message(STATUS "Loading configration: " ${PROJECT_SOURCE_DIR}/config/${CONFIG}.cmake)
@@ -23,6 +28,10 @@ option(Document "Build HTML document" OFF)
 option(USE_SYSTEM_BOOST "use Boost installed in system" OFF)
 
 enable_language(C CXX)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  add_compile_options(-Wall)
+endif()
 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_SKIP_BUILD_RPATH FALSE)


### PR DESCRIPTION
## Summary

Build-configuration fixes split out of the bug-fix PR (fix-cpp-issues) #51 as
requested. Single commit, no source-code changes.

## Changes

- **Fix the AddressSanitizer Debug flags**: `CMAKE_CXX_FLAGS_DEBUG` paired
  ASan with `-fomit-frame-pointer`, which destroys ASan's stack traces —
  almost certainly a typo for `-fno-omit-frame-pointer`. Use the latter and
  also pass `-fsanitize=address` at link time so a Debug build links out of
  the box.
- **Pin `CMAKE_CXX_STANDARD` to 11** (with `CMAKE_CXX_STANDARD_REQUIRED`).
  Previously no standard was set anywhere, so the code was compiled with
  whatever the host compiler defaults to (C++17 on recent GCC/Clang), i.e.
  the effective language level silently changed from machine to machine.
- **Enable `-Wall` for GCC/Clang** (no `-Werror`).
- **Raise the CMake minimum from 2.8.12 to 3.1**, required for
  `CMAKE_CXX_STANDARD`. (2.8.12 is long deprecated; the existing
  `2.8.12...3.20.2` range syntax still works on CMake 4.x, so this is a
  prerequisite bump, not a compatibility fix.)

## Verification

- Clean reconfigure and full rebuild of all targets with CMake 4.3 /
  AppleClang 16 and with the CI toolchain (Ubuntu GCC).
- Fixed-seed reference runs of dla and pmwa_H are bit-identical to builds
  made with the previous configuration, confirming the standard pin does
  not change behavior.
- A Debug (ASan) build of dla compiles, links, and runs the reference
  workloads with no sanitizer reports.

## Note for maintainers

The pending `remove-boost` and RNG-replacement PRs rely on the C++11 pin
introduced here (`<chrono>`, `<random>`, `<unordered_map>`), so this PR
should merge before those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)