### PR TITLE
Make beta validation robust under fast-math (drop the inf sentinel)

### DIFF
--- a/src/common/fpcheck.h
+++ b/src/common/fpcheck.h
@@ -17,15 +17,25 @@
 #ifndef SRC_COMMON_FPCHECK_H_
 #define SRC_COMMON_FPCHECK_H_
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 
 // Floating-point classification via integer bit operations.
 // std::isfinite / std::isnan may be constant-folded away under
 // -ffast-math (and the default fp-model of the Intel compilers),
-// while these keep working under any compiler flags.
+// while the bit tests keep working under any compiler flags.
+// The bit layout assumes IEEE-754 binary64; on exotic platforms
+// where double is something else, fall back to the std functions
+// (the fast-math concern does not arise for those FP formats anyway).
 
 namespace dsqss {
+
+inline bool double_is_ieee754() {
+  return std::numeric_limits<double>::is_iec559 &&
+         sizeof(double) == sizeof(std::uint64_t);
+}
 
 inline std::uint64_t double_bits(double v) {
   std::uint64_t u;
@@ -35,12 +45,18 @@ inline std::uint64_t double_bits(double v) {
 
 // true iff v is neither infinite nor NaN
 inline bool is_finite(double v) {
-  return ((double_bits(v) >> 52) & 0x7ffULL) != 0x7ffULL;
+  if (double_is_ieee754()) {
+    return ((double_bits(v) >> 52) & 0x7ffULL) != 0x7ffULL;
+  }
+  return std::isfinite(v);
 }
 
 inline bool is_nan(double v) {
-  const std::uint64_t u = double_bits(v);
-  return ((u >> 52) & 0x7ffULL) == 0x7ffULL && (u & 0xfffffffffffffULL) != 0;
+  if (double_is_ieee754()) {
+    const std::uint64_t u = double_bits(v);
+    return ((u >> 52) & 0x7ffULL) == 0x7ffULL && (u & 0xfffffffffffffULL) != 0;
+  }
+  return std::isnan(v);
 }
 
 }  // namespace dsqss

--- a/src/common/fpcheck.h
+++ b/src/common/fpcheck.h
@@ -1,0 +1,48 @@
+// DSQSS (Discrete Space Quantum Systems Solver)
+// Copyright (C) 2018- The University of Tokyo
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef SRC_COMMON_FPCHECK_H_
+#define SRC_COMMON_FPCHECK_H_
+
+#include <cstdint>
+#include <cstring>
+
+// Floating-point classification via integer bit operations.
+// std::isfinite / std::isnan may be constant-folded away under
+// -ffast-math (and the default fp-model of the Intel compilers),
+// while these keep working under any compiler flags.
+
+namespace dsqss {
+
+inline std::uint64_t double_bits(double v) {
+  std::uint64_t u;
+  std::memcpy(&u, &v, sizeof(u));
+  return u;
+}
+
+// true iff v is neither infinite nor NaN
+inline bool is_finite(double v) {
+  return ((double_bits(v) >> 52) & 0x7ffULL) != 0x7ffULL;
+}
+
+inline bool is_nan(double v) {
+  const std::uint64_t u = double_bits(v);
+  return ((u >> 52) & 0x7ffULL) == 0x7ffULL && (u & 0xfffffffffffffULL) != 0;
+}
+
+}  // namespace dsqss
+
+#endif  // SRC_COMMON_FPCHECK_H_

--- a/src/common/from_string.h
+++ b/src/common/from_string.h
@@ -23,12 +23,16 @@
 #include <stdexcept>
 #include <string>
 
+#include "fpcheck.h"
+
 // Strict string-to-number conversion replacing boost::lexical_cast:
 // the whole string (after optional leading whitespace) must be
 // consumed, otherwise std::runtime_error is thrown, so inputs like
 // "12abc" are rejected instead of being silently truncated.
-// "inf" / "nan" are accepted for doubles; the parameter defaults rely
-// on from_string<double>("inf") returning infinity.
+// "inf" is accepted for doubles (simulationtime = INF relies on it),
+// but "nan" is rejected: a NaN sneaking in would silently pass every
+// later comparison, and it cannot be detected downstream because
+// std::isnan is unreliable under -ffast-math.
 
 template <typename T>
 T from_string(const std::string& s);
@@ -44,6 +48,10 @@ inline double from_string<double>(const std::string& s) {
   }
   if (errno == ERANGE) {
     throw std::runtime_error("from_string: out of range: \"" + s + "\"");
+  }
+  if (dsqss::is_nan(v)) {
+    throw std::runtime_error("from_string: nan is not allowed: \"" + s +
+                             "\"");
   }
   return v;
 }

--- a/src/dla/lattice.hpp
+++ b/src/dla/lattice.hpp
@@ -17,7 +17,6 @@
 #ifndef SRC_DLA_LATTICE_HPP_
 #define SRC_DLA_LATTICE_HPP_
 
-#include <cmath>
 #include <cstdio>
 #include <exception>
 #include <string>
@@ -111,7 +110,7 @@ inline Lattice::Lattice(Parameter const& P, Algorithm& A) : ALG(A) {
   X.initialize(P.LATFILE, "LATTICE");
   read();
 
-  if (std::isfinite(P.BETA)) {
+  if (P.BETA > 0.0) {
     setBeta(P.BETA);
   }
 

--- a/src/dla/parameter.hpp
+++ b/src/dla/parameter.hpp
@@ -2,7 +2,6 @@
 #define SRC_DLA_PARAMETER_HPP_
 
 #include <cctype>
-#include <cmath>
 #include <cstdio>
 #include <cstring>
 
@@ -127,8 +126,8 @@ void Parameter::readfile(std::string const& filename) {
   deprecated_parameter(dict, "ntherm", "nmcsd");
 
   BETA = from_string<double>(dict["beta"]);
-  if (std::isinf(BETA) || BETA <= 0.0) {
-    util::ERROR("\"beta\" is not specified or invalid.");
+  if (!dsqss::is_finite(BETA) || BETA <= 0.0) {
+    util::ERROR("specify positive \"beta\".");
   }
 
   NMCS = from_string<int>(dict["nmcs"]);
@@ -202,7 +201,7 @@ inline Parameter::Parameter(int NP, char** PLIST) {
 
 void Parameter::init(std::map<std::string, std::string>& dict) {
   dict.clear();
-  dict["beta"] = "inf";
+  dict["beta"] = "-1.0";
   dict["nmcs"] = "1000";
   dict["nset"] = "10";
   dict["npre"] = "1000";

--- a/src/pmwa/PMWA.cpp
+++ b/src/pmwa/PMWA.cpp
@@ -233,6 +233,9 @@ void Dla::ReadParameterfile(int m_pnum, int m_myrank, int NP, char **PLIST) {
     throw std::runtime_error("specify positive \"beta\".");
   }
   oldBETA = from_string<double>(dict["oldbeta"]);
+  if (!dsqss::is_finite(oldBETA)) {
+    throw std::runtime_error("specify finite \"oldbeta\".");
+  }
 
   deprecated_parameter(dict, "t", "tb");
   deprecated_parameter(dict, "u", "ub");

--- a/src/pmwa/PMWA.cpp
+++ b/src/pmwa/PMWA.cpp
@@ -80,13 +80,11 @@ double Dla::PMWA() {
   AutoPlog("");
   Lattice LT(latfile);
 
-  if (!std::isinf(BETA)) {
-    LT.set_beta(BETA);
-  }
+  LT.set_beta(BETA);
   PR.FlgAnneal = false;
   PR.FlgRestart = (MC.runtype == Restart);
   if (PR.FlgRestart) {
-    if (!std::isinf(oldBETA)) {
+    if (oldBETA > 0.0) {
       LT.set_oldbeta(oldBETA);
       PR.FlgAnneal = true;
       PR.FlgRestart = false;
@@ -231,6 +229,9 @@ void Dla::ReadParameterfile(int m_pnum, int m_myrank, int NP, char **PLIST) {
   MC.seed = from_string<int>(dict["seed"]);
 
   BETA = from_string<double>(dict["beta"]);
+  if (!dsqss::is_finite(BETA) || BETA <= 0.0) {
+    throw std::runtime_error("specify positive \"beta\".");
+  }
   oldBETA = from_string<double>(dict["oldbeta"]);
 
   deprecated_parameter(dict, "t", "tb");
@@ -277,8 +278,8 @@ void Dla::init_paramdict(std::map<std::string, std::string> &dict) {
   dict["nvermax"] = "100000000";
   dict["nwormax"] = "1000";
 
-  dict["beta"] = "Inf";
-  dict["oldbeta"] = "Inf";
+  dict["beta"] = "-1.0";
+  dict["oldbeta"] = "-1.0";
 
   dict["g"] = "0.2";
   dict["t"] = "1.0";


### PR DESCRIPTION
## Summary

`std::isinf` / `std::isfinite` are unreliable under fast-math compiler flags
(`-ffast-math`, `-Ofast`, and the **default** fp-model of the Intel compilers):
the compiler assumes no infinities or NaNs exist and folds the checks into
constants. The "beta not specified" detection, which parsed the default
string `"inf"` into an infinity and tested it with `std::isinf`, silently
breaks under such flags — dla would run with beta = inf instead of reporting
an error, and pmwa would override the lattice-file beta with inf.
(This weakness predates #53: `boost::math::isinf` delegated to
`std::isinf` as well.)

## Changes

- The default for unspecified `beta` / `oldbeta` is now `-1.0`. Negative
  beta is unphysical, and comparisons between *finite* values are safe under
  any compiler flags. dla and pmwa report `specify positive "beta".` for a
  missing, zero, or negative beta.
- New `src/common/fpcheck.h` provides `dsqss::is_finite` / `dsqss::is_nan`,
  bit-level (integer) classification helpers that fast-math cannot optimize
  away. beta validation uses `dsqss::is_finite`, so an explicit `beta = inf`
  is rejected too.
- `from_string<double>` now rejects `"nan"` (any spelling: `nan`, `NaN`,
  `-nan`, `nan(...)`). A NaN would silently pass every later comparison
  (NaN comparisons are false even without fast-math) and cannot be detected
  downstream. `"inf"` stays accepted — `simulationtime = INF` relies on it —
  and overflow to infinity is still caught via `ERANGE`.
- `<cmath>` includes that only supported the removed `isinf`/`isfinite`
  calls are dropped.

## Behavior changes

- **pmwa: `beta` is now effectively required in the parameter file.** The
  undocumented fallback to `<Beta>` in the lattice XML is removed. Every
  sample, test, and `pmwa_pre` (default 10.0) always writes `beta`, so no
  supported workflow is affected. Annealing on restart is triggered by
  `oldbeta > 0` exactly as before.
- `beta = nan` / `beta = inf` / `beta = 0` now abort with a clear message
  in both dla and pmwa (previously pmwa passed them through to `set_beta`).

## Verification

- Full clean Release build; `ctest` 36/36 pass (including the checkpoint
  test exercising `simulationtime = INF` and the pmwa annealing/restart
  tests exercising the `oldbeta` logic).
- Manual error-path checks: `beta` unspecified / `0` / `-3` / `inf` /
  `-inf` → `specify positive "beta".`; `nan` / `NaN` / `-nan` /
  `nan(0x1)` → `from_string: nan is not allowed`; `1e999` →
  `from_string: out of range`; valid values proceed as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEBs3PghnEohrNWg5pNRhv