### PR TITLE
Make the dla test cleanup() actually remove stale files

### DIFF
--- a/test/dla/common.py
+++ b/test/dla/common.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import subprocess as sub
 import sys
@@ -28,15 +29,23 @@ def cleanup(name=""):
         ("lattice", ".xml"),
         ("wavevector", ".xml"),
         ("displacement", ".xml"),
+        ("wv", ".xml"),
+        ("dp", ".xml"),
         ("res", ".dat"),
         ("sf", ".dat"),
         ("cf", ".dat"),
         ("ck", ".dat"),
-        ("cjob.res", ".dat"),
     ]:
         fname = "{0}{1}{2}".format(prefix, name, suffix)
         if os.path.exists(fname):
             os.remove(fname)
+    # Checkpoint files (res<name>.dat.<rank>.cjob and their .tmp): a stale
+    # one left by an interrupted run would be loaded by the next dla run,
+    # which then skips the simulation instead of starting fresh.
+    for fname in glob.glob("res{0}.dat.*.cjob".format(name)) + glob.glob(
+        "res{0}.dat.*.cjob.tmp".format(name)
+    ):
+        os.remove(fname)
 
 
 def geninp(param, seed, simtime=0.0, name=""):


### PR DESCRIPTION
## Summary

`cleanup()` in `test/dla/common.py` looked for two kinds of files under names
that are never generated, so they were silently left behind:

- **Checkpoint files**: the entry `("cjob.res", ".dat")` built
  `cjob.res_<name>.dat`, but dla writes `res<name>.dat.<rank>.cjob`
  (`chainjob.hpp`). A stale checkpoint left by an interrupted run is loaded
  by the next dla run, which then reports
  `This simulation has been finished or suspended before setting Ncycle` and
  skips the simulation instead of starting fresh — the checkpoint test keeps
  failing until the file is removed by hand. `cleanup()` now removes the real
  names (and their `.tmp`) via glob.
- **Wavevector / displacement inputs**: `geninp()` writes `wv<name>.xml` and
  `dp<name>.xml`, while `cleanup()` looked for `wavevector<name>.xml` and
  `displacement<name>.xml`. The actual prefixes are added (the old entries are
  kept for compatibility).

Test-only change; no simulation code is touched.

## Verification

- Reproduced the failure mode: ran dla with `simulationtime = 1.0` so it
  suspends and leaves `res_checkpoint.dat.0.cjob`, then ran the checkpoint
  test. It fails without this change and passes with it, and the stale
  checkpoint is gone afterwards.
- Full `ctest`: 36/36 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEBs3PghnEohrNWg5pNRhv